### PR TITLE
No need to run the rust workflow on the main branch

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -3,8 +3,6 @@ package workflows
 rust: _#useMergeQueue & {
 	name: "rust"
 
-	on: push: branches: [defaultBranch]
-
 	env: {
 		CARGO_INCREMENTAL: 0
 		CARGO_TERM_COLOR:  "always"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,9 +8,6 @@ name: rust
   merge_group:
     types:
       - checks_requested
-  push:
-    branches:
-      - main
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
With the merge queue setup, it has already ran and passed on the PR itself, and then a second time in the merge queue, where the commit should retain it's checks status. I'll double-check that with our current caching setup, we don't have an issue, but I think this should still work as expected.