### PR TITLE
Skip lints and formatting once in the merge queue

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -32,7 +32,7 @@ rust: _#useMergeQueue & {
 			name: "format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.rust == 'true' }}"
+			if:        "${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}"
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -48,7 +48,7 @@ rust: _#useMergeQueue & {
 			name: "lint"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.rust == 'true' }}"
+			if:        "${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}"
 			steps: [
 				_#checkoutCode,
 				_#installRust,

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -12,7 +12,7 @@ wordsmith: _#useMergeQueue & {
 			name: "markdown / format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.markdown == 'true' }}"
+			if:        "${{ needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request' }}"
 			steps: [
 				_#checkoutCode,
 				_#prettier & {
@@ -27,6 +27,7 @@ wordsmith: _#useMergeQueue & {
 			name: "spellcheck"
 			needs: ["changes"]
 			"runs-on": defaultRunner
+			if:        "${{ github.event_name == 'pull_request' }}"
 			steps: [
 				_#checkoutCode,
 				_#codespell,

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -97,7 +97,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.markdown == 'true' }}
+    if: ${{ needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -65,6 +65,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab


### PR DESCRIPTION
Each individual PR will have to pass these tests, and if they are mergable together without conflicts, we should be okay to just compile and test. This should save some compute time.