### PR TITLE
Ensure Rust tests run even if format/lint are skipped

### DIFF
--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -12,7 +12,7 @@ githubActions: _#useMergeQueue & {
 			name: "cue / vet"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.github-actions == 'true' }}"
+			if:        "needs.changes.outputs.github-actions == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installCue,

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -71,6 +71,7 @@ rust: _#useMergeQueue & {
 				]
 			}
 			"runs-on": "${{ matrix.platform }}"
+			if:        "needs.changes.outputs.rust == 'true' && always()"
 			steps: [
 				_#checkoutCode,
 				_#installRust,

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -17,7 +17,7 @@ rust: _#useMergeQueue & {
 			name: "check"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.rust == 'true' }}"
+			if:        "needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -30,7 +30,7 @@ rust: _#useMergeQueue & {
 			name: "format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}"
+			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -46,7 +46,7 @@ rust: _#useMergeQueue & {
 			name: "lint"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}"
+			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
 				_#installRust,

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -12,7 +12,7 @@ wordsmith: _#useMergeQueue & {
 			name: "markdown / format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request' }}"
+			if:        "needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
 				_#prettier & {
@@ -27,7 +27,7 @@ wordsmith: _#useMergeQueue & {
 			name: "spellcheck"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "${{ github.event_name == 'pull_request' }}"
+			if:        "github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
 				_#codespell,

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.github-actions == 'true' }}
+    if: needs.changes.outputs.github-actions == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.platform }}
+    if: needs.changes.outputs.rust == 'true' && always()
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -74,7 +74,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}
+    if: needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -94,7 +94,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}
+    if: needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request' }}
+    if: needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -65,7 +65,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab


### PR DESCRIPTION
I think this will work, but we'll have to merge to find out by watching the Actions runs on the merge queue itself.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-not-requiring-successful-dependent-jobs
- https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions