### PR TITLE
Ensure MSRV tests run even if format/lint are skipped

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -97,6 +97,7 @@ rust: _#useMergeQueue & {
 			name: "check / msrv"
 			needs: ["check", "format", "lint"]
 			"runs-on": defaultRunner
+			if:        "needs.changes.outputs.rust == 'true' && always()"
 			steps: [
 				_#checkoutCode,
 				{

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,6 +156,7 @@ jobs:
       - format
       - lint
     runs-on: ubuntu-latest
+    if: needs.changes.outputs.rust == 'true' && always()
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab


### PR DESCRIPTION
Similar change to https://github.com/earthmanmuons/rustops-blueprint/pull/61