### PR TITLE
Lint the CUE files as part of github-actions xtask

### DIFF
--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -39,6 +39,13 @@ pub fn format_rust() -> Result<(), DynError> {
     Ok(())
 }
 
+pub fn lint_cue() -> Result<(), DynError> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, cue_dir());
+    cmd!(sh, "cue vet --concrete").run()?;
+    Ok(())
+}
+
 pub fn lint_rust() -> Result<(), DynError> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,9 +28,9 @@ fn main() -> Result<(), DynError> {
 }
 
 pub mod tasks {
-    use crate::fixup::{
-        format_cue, format_markdown, format_rust, lint_rust, regenerate_ci_yaml, spellcheck,
-    };
+    use crate::fixup::{format_cue, format_markdown, format_rust};
+    use crate::fixup::{lint_cue, lint_rust};
+    use crate::fixup::{regenerate_ci_yaml, spellcheck};
     use crate::DynError;
 
     pub fn fixup() -> Result<(), DynError> {
@@ -41,6 +41,7 @@ pub mod tasks {
     }
 
     pub fn fixup_github_actions() -> Result<(), DynError> {
+        lint_cue()?;
         format_cue()?;
         regenerate_ci_yaml()
     }


### PR DESCRIPTION
This matches what we do in CI and makes more logical sense to bubble up any errors in a dedicated step as an indication of how developers can troubleshoot.