### PR TITLE
Update references from elasticdog to EarthmanMuons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/elasticdog/rustops-blueprint/tree/main
+[unreleased]: https://github.com/EarthmanMuons/rustops-blueprint/tree/main

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # RustOps Blueprint &emsp; [![CI Status]][actions]
 
 [CI Status]:
-  https://img.shields.io/github/checks-status/elasticdog/rustops-blueprint/main?label=CI&logo=github
+  https://img.shields.io/github/actions/workflow/status/EarthmanMuons/rustops-blueprint/rust.yml?event=merge_group&label=CI&logo=github
 [actions]:
-  https://github.com/elasticdog/rustops-blueprint/actions?query=branch%3Amain
+  https://github.com/EarthmanMuons/rustops-blueprint/actions?query=event%3Amerge_group
 
 **A GitHub repository template for a polished Rust development experience.**
 


### PR DESCRIPTION
I've moved the repository into an organization rather than having it under my individual account so we'll have access to GitHub's merge queues feature.