### PR TITLE
Flesh out the cargo manifest values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,14 @@ members = ["crates/*", "xtask/"]
 
 [workspace.package]
 version = "0.1.0"
+authors = ["Aaron Bull Schaefer <aaron@elasticdog.com>"]
 edition = "2021"
 rust-version = "1.64"
+description = "My binary description."
+documentation = "https://github.com/EarthmanMuons/rustops-blueprint/"
+readme = "README.md"
+homepage= "https://github.com/EarthmanMuons/rustops-blueprint/"
+repository = "https://github.com/EarthmanMuons/rustops-blueprint/"
 license = "MIT OR Apache-2.0"
 
 [profile.dev]

--- a/crates/mybin/Cargo.toml
+++ b/crates/mybin/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "mybin"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/mybin/README.md
+++ b/crates/mybin/README.md
@@ -1,0 +1,19 @@
+# mybin
+
+My binary description.
+
+## Installation
+
+To build the binary and install it on your system under the `~/.cargo/bin`
+directory, run the following command:
+
+```
+cargo install --git https://github.com/EarthmanMuons/rustops-blueprint/ mybin
+```
+
+## Usage
+
+    $ mybin
+    Hello, world! 10 plus 32 is 42!
+    Unshuffled: [1, 2, 3, 4, 5]
+    Shuffled:   [1, 3, 5, 4, 2]

--- a/crates/mylib/Cargo.toml
+++ b/crates/mylib/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "mylib"
 version.workspace = true
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "My library description."
+documentation = "https://earthmanmuons.github.io/rustops-blueprint/mylib/index.html"
+readme.workspace = true
+homepage = "https://github.com/EarthmanMuons/rustops-blueprint/tree/main/crates/mylib"
+repository = "https://github.com/EarthmanMuons/rustops-blueprint/tree/main/crates/mylib"
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/mylib/README.md
+++ b/crates/mylib/README.md
@@ -1,0 +1,20 @@
+# mylib
+
+My library description.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+mylib = "0.1.0"
+```
+
+## License
+
+mylib is distributed under the terms of both the Apache License (Version 2.0)
+and the MIT License.
+
+See [LICENSE-APACHE](../../LICENSE-APACHE) and [LICENSE-MIT](../../LICENSE-MIT)
+for details.


### PR DESCRIPTION
Certain fields are required before publishing, although it's likely that most binaries shouldn't be published to the crates.io central package registry. I may need to tweak some things here, but it's a start.

See:
- https://doc.rust-lang.org/cargo/reference/manifest.html
- https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
- https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate