### PR TITLE
Make sure that cargo-nextest is cached as well

### DIFF
--- a/.github/cue/preload-cache.cue
+++ b/.github/cue/preload-cache.cue
@@ -49,6 +49,7 @@ preloadCache: {
 				_#checkoutCode,
 				_#installRust,
 				_#cacheRust,
+				_#installTool & {with: tool: "cargo-nextest"},
 				_#cargoCheck,
 			]
 		}

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -75,8 +75,8 @@ rust: _#useMergeQueue & {
 			steps: [
 				_#checkoutCode,
 				_#installRust,
-				_#installTool & {with: tool: "cargo-nextest"},
 				_#cacheRust,
+				_#installTool & {with: tool: "cargo-nextest"},
 				{
 					name: "Compile tests"
 					run:  "cargo test --locked --no-run"

--- a/.github/workflows/preload-cache.yml
+++ b/.github/workflows/preload-cache.yml
@@ -46,6 +46,10 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: workflow
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
+        with:
+          tool: cargo-nextest
       - name: Check packages and dependencies for errors
         run: cargo check --locked
   check_msrv:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,14 +135,14 @@ jobs:
         with:
           toolchain: stable
           components: clippy,rustfmt
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
-        with:
-          tool: cargo-nextest
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: workflow
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
+        with:
+          tool: cargo-nextest
       - name: Compile tests
         run: cargo test --locked --no-run
       - name: Run tests


### PR DESCRIPTION
The order matters here since rust-cache cleans out any files in `~/.cargo/bin` that were present **before the action ran**, which means we'll want to install nextest **after** running the cache job. The install-action job will check for newer versions appropriately.

The one thing I'm not sure about is if rust-cache will key based off of the contents of the `~/.cargo/bin` directory, or if it's just saving that into the cache. If it does key off of the contents, we may need to always install nextest even if it's not going to be used (for check/ format/lint jobs) so we can maintain cache efficiency.

See:
- https://github.com/Swatinem/rust-cache#cache-details
- https://github.com/taiki-e/install-action/issues/66