### PR TITLE
Flush caches when preload-cache is triggered manually

### DIFF
--- a/.github/cue/workflows.cue
+++ b/.github/cue/workflows.cue
@@ -45,15 +45,15 @@ _#useMergeQueue: _#pullRequestWorkflow & {
 			for jobId in needs {
 				name: "Check status of job_id: \(jobId)"
 				run:  """
-						RESULT="${{ needs.\(jobId).result }}";
-						if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
-						    exit 0
-						else
-						    echo "***"
-						    echo "Error: The required job did not pass."
-						    exit 1
-						fi
-						"""
+					RESULT="${{ needs.\(jobId).result }}";
+					if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+					    exit 0
+					else
+					    echo "***"
+					    echo "Error: The required job did not pass."
+					    exit 1
+					fi
+					"""
 			},
 		]
 	}

--- a/.github/workflows/preload-cache.yml
+++ b/.github/workflows/preload-cache.yml
@@ -21,8 +21,29 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
 jobs:
-  check_stable:
-    name: check / stable
+  flush_caches:
+    name: flush caches
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: write
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Flush main branch caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          gh extension install actions/gh-actions-cache
+          REPO=${{ github.repository }}
+          BRANCH="refs/heads/main"
+          cacheKeys=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1)
+          set +e
+          for key in $cacheKeys; do
+              gh actions-cache delete "$key" -R $REPO -B $BRANCH --confirm
+          done
+  cache_stable:
+    name: cache / stable
     defaults:
       run:
         shell: bash
@@ -52,8 +73,8 @@ jobs:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
         run: cargo check --locked
-  check_msrv:
-    name: check / msrv
+  cache_msrv:
+    name: cache / msrv
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
An admittedly minor edge case, but we may want to manually flush old caches if new tooling is installed or we want to pick up a new version of Rust stable after a release and before a main branch job is triggered automatically.

See:
- https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
- https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
- https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy