### PR TITLE
Differentiate the platforms in Rust cache names

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -75,8 +75,8 @@ rust: _#useMergeQueue & {
 			steps: [
 				_#checkoutCode,
 				_#installRust,
-				_#cacheRust,
-				_#installTool & {with: tool: "cargo-nextest"},
+				_#cacheRust & {with: "shared-key": "stable-${{ matrix.platform }}"},
+				_#installTool & {with: tool:       "cargo-nextest"},
 				{
 					name: "Compile tests"
 					run:  "cargo test --locked --no-run"
@@ -105,8 +105,8 @@ rust: _#useMergeQueue & {
 					id:   "msrv"
 					run:  "awk -F '\"' '/rust-version/{ print \"version=\" $2 }' Cargo.toml >> $GITHUB_OUTPUT"
 				},
-				_#installRust & {with: toolchain: "${{ steps.msrv.outputs.version }}"},
-				_#cacheRust,
+				_#installRust & {with: toolchain:  "${{ steps.msrv.outputs.version }}"},
+				_#cacheRust & {with: "shared-key": "msrv-\(defaultRunner)"},
 				_#cargoCheck,
 			]
 		}

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -21,7 +21,7 @@ _#cacheRust: _#step & {
 	uses: "Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f"
 
 	// share the cache across all workflow jobs instead of keying on job_id 
-	with: "shared-key": *"workflow" | string
+	with: "shared-key": *"stable-\(defaultRunner)" | string
 }
 
 _#cargoCheck: _#step & {

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-ubuntu-latest
       - name: Install cargo-nextest
         uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
         with:
@@ -94,6 +94,6 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-ubuntu-latest
       - name: Check packages and dependencies for errors
         run: cargo check --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-ubuntu-latest
       - name: Check packages and dependencies for errors
         run: cargo check --locked
   format:
@@ -86,7 +86,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-ubuntu-latest
       - name: Check formatting
         run: cargo fmt --check
   lint:
@@ -106,7 +106,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-ubuntu-latest
       - name: Check lints
         run: cargo clippy --no-deps -- -D warnings
   test_stable:
@@ -138,7 +138,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: stable-${{ matrix.platform }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
         with:
@@ -171,7 +171,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: workflow
+          shared-key: msrv-ubuntu-latest
       - name: Check packages and dependencies for errors
         run: cargo check --locked
   merge_queue:


### PR DESCRIPTION
This should make it much more obvious which cache comes from which job/ version/platform combination.