### PR TITLE
Match preload-caches keys with regular Rust workflow

### DIFF
--- a/.github/cue/preload-caches.cue
+++ b/.github/cue/preload-caches.cue
@@ -78,8 +78,8 @@ preloadCaches: {
 			steps: [
 				_#checkoutCode,
 				_#installRust,
-				_#cacheRust,
-				_#installTool & {with: tool: "cargo-nextest"},
+				_#cacheRust & {with: "shared-key": "stable-${{ matrix.platform }}"},
+				_#installTool & {with: tool:       "cargo-nextest"},
 				_#cargoCheck,
 			]
 		}
@@ -97,8 +97,8 @@ preloadCaches: {
 					id:   "msrv"
 					run:  "awk -F '\"' '/rust-version/{ print \"version=\" $2 }' Cargo.toml >> $GITHUB_OUTPUT"
 				},
-				_#installRust & {with: toolchain: "${{ steps.msrv.outputs.version }}"},
-				_#cacheRust,
+				_#installRust & {with: toolchain:  "${{ steps.msrv.outputs.version }}"},
+				_#cacheRust & {with: "shared-key": "msrv-\(defaultRunner)"},
 				_#cargoCheck,
 			]
 		}

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: stable-ubuntu-latest
+          shared-key: stable-${{ matrix.platform }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
         with:
@@ -96,6 +96,6 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
-          shared-key: stable-ubuntu-latest
+          shared-key: msrv-ubuntu-latest
       - name: Check packages and dependencies for errors
         run: cargo check --locked


### PR DESCRIPTION
I missed this in the other commit.