### PR TITLE
Install clippy/rustfmt only when necessary

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -33,7 +33,7 @@ rust: _#useMergeQueue & {
 			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
-				_#installRust,
+				_#installRust & {with: components: "rustfmt"},
 				_#cacheRust,
 				{
 					name: "Check formatting"
@@ -49,7 +49,7 @@ rust: _#useMergeQueue & {
 			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
-				_#installRust,
+				_#installRust & {with: components: "clippy"},
 				_#cacheRust,
 				{
 					name: "Check lints"

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -62,8 +62,8 @@ _#installRust: _#step & {
 	// NOTE: upstream does not tag releases, so this won't be updated by dependabot
 	uses: "dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d"
 	with: {
-		toolchain:  *"stable" | string
-		components: *"clippy,rustfmt" | string
+		toolchain:   *"stable" | string
+		components?: string
 	}
 }
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,7 +26,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: nightly
-          components: clippy,rustfmt
       - name: Build docs
         env:
           RUSTDOCFLAGS: --enable-index-page -Z unstable-options

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -65,7 +65,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: stable
-          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
@@ -92,7 +91,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
-          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: stable
-          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
@@ -82,7 +81,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: stable
-          components: clippy,rustfmt
+          components: rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
@@ -102,7 +101,7 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: stable
-          components: clippy,rustfmt
+          components: clippy
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
@@ -134,7 +133,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: stable
-          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
@@ -167,7 +165,6 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
-          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:


### PR DESCRIPTION
With how rust-cache works, I think these component binaries will be ignored when keying and won't bust the cache, so we don't have to waste time installing them when they're not used.