### PR TITLE
Remove explicit branch ref when checking out the scheduled job

### DIFF
--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -27,7 +27,7 @@ scheduled: {
 		name:      "direct-minimal-versions / stable"
 		"runs-on": defaultRunner
 		steps: [
-			_#checkoutCode & {with: ref: defaultBranch},
+			_#checkoutCode,
 			_#installRust,
 			_#installRust & {with: toolchain: "nightly"},
 			{

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          ref: main
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:


### PR DESCRIPTION
The checkout action will always use the default branch if it's run on a job that wasn't triggered by a specific different branch, so no need for us to override the behavior here.

See:
- https://github.com/actions/checkout#usage