### PR TITLE
Allow clippy runs during the fixup.rust xtask to error out

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -53,7 +53,7 @@ rust: _#useMergeQueue & {
 				_#cacheRust,
 				{
 					name: "Check lints"
-					run:  "cargo clippy --no-deps -- -D warnings"
+					run:  "cargo clippy --all-targets --all-features -- -D warnings"
 				},
 			]
 		}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           shared-key: stable-ubuntu-latest
       - name: Check lints
-        run: cargo clippy --no-deps -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
   test_stable:
     name: test / stable
     needs:

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -49,7 +49,21 @@ pub fn lint_cue() -> Result<(), DynError> {
 pub fn lint_rust() -> Result<(), DynError> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
-    cmd!(sh, "cargo clippy --fix --allow-no-vcs -- -D warnings").run()?;
+    cmd!(
+        sh,
+        "cargo fix --allow-no-vcs --all-features --edition-idioms"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "cargo clippy --all-targets --all-features --fix --allow-no-vcs"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "cargo clippy --all-targets --all-features -- -D warnings"
+    )
+    .run()?;
     Ok(())
 }
 


### PR DESCRIPTION
When running clippy with the `--fix` flag, it will demote all errors into warnings rather than halt if it can't fix the issue automatically. To make sure that we actually address any clippy lints, we need to re-run it afterward without the `--fix` flag, but ensuring that all warnings are treated as errors.

Note that I've removed the `--no-deps` flag, as for clippy, that is used when you only want to test a single package within a workspace, not for looking at third-party dependencies.

We've also added in a `cargo fix` step to handle changes that the compiler can do itself (outside of clippy), while preferring to adopt any of the current Rust edition's idioms.

See:
- https://github.com/rust-lang/rust-clippy/discussions/9979
- https://doc.rust-lang.org/stable/clippy/usage.html#workspaces
- https://doc.rust-lang.org/cargo/commands/cargo-fix.html