### PR TITLE
Timeout the Rust cache step after five minutes

### DIFF
--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -22,6 +22,7 @@ _#cacheRust: _#step & {
 
 	// share the cache across all workflow jobs instead of keying on job_id 
 	with: "shared-key": *"stable-\(defaultRunner)" | string
+	"timeout-minutes": 5
 }
 
 _#cargoCheck: _#step & {

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -69,6 +69,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: stable-${{ matrix.platform }}
+        timeout-minutes: 5
       - name: Install cargo-nextest
         uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
         with:
@@ -95,5 +96,6 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: msrv-ubuntu-latest
+        timeout-minutes: 5
       - name: Check packages and dependencies for errors
         run: cargo check --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: stable-ubuntu-latest
+        timeout-minutes: 5
       - name: Check packages and dependencies for errors
         run: cargo check --locked
   format:
@@ -86,6 +87,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: stable-ubuntu-latest
+        timeout-minutes: 5
       - name: Check formatting
         run: cargo fmt --check
   lint:
@@ -106,6 +108,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: stable-ubuntu-latest
+        timeout-minutes: 5
       - name: Check lints
         run: cargo clippy --all-targets --all-features -- -D warnings
   test_stable:
@@ -137,6 +140,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: stable-${{ matrix.platform }}
+        timeout-minutes: 5
       - name: Install cargo-nextest
         uses: taiki-e/install-action@a775aaf2e8ed709f76ee019cb77e39fc50613631
         with:
@@ -169,6 +173,7 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
         with:
           shared-key: msrv-ubuntu-latest
+        timeout-minutes: 5
       - name: Check packages and dependencies for errors
         run: cargo check --locked
   merge_queue:


### PR DESCRIPTION
I had an instance where, for whatever reason, it got stuck restoring the cache and took an hour before it timed out and moved on. I tried to cancel the job run, but it did not have an effect, so everything was stuck until the timeout was reached. It should be fine if the cache is missed, as it's purely an optimization, but I want to wait long enough where I'd probably notice if it starts timing out regularly.

This was the output on the job:

    [...]
    Received 167485073 of 171679377 (97.6%), 1.6 MBs/sec
    Received 167485073 of 171679377 (97.6%), 1.6 MBs/sec
    Warning: Failed to restore: The operation cannot be completed in timeout.
    No cache found.