### PR TITLE
Add issue templates and configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+**Describe the Bug**
+
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce**
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected Behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual Behavior**
+
+A clear and concise descriptino of what actually happened.
+
+If applicable, add screenshots to help explain your problem.
+
+**Additional Context**
+
+Add any other context about the problem here. Environmental details, software
+versions used, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Community Conversations
+    url: https://github.com/EarthmanMuons/rustops-blueprint/discussions
+    about: Please ask and answer questions here.
+  - name: Security Concerns
+    url: https://github.com/EarthmanMuons/rustops-blueprint/security/policy
+    about: Please go here to learn about reporting security vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+**Motivation**
+
+A clear and concise description of what the motivation for the new feature is,
+and what problem it is solving.
+
+**Proposed Solution**
+
+A clear and concise description of the feature you would like to add, and how it
+solves the motivating problem.
+
+**Alternatives**
+
+A clear and concise description of any alternative solutions or features you've
+considered, and why you're proposed solution is better.
+
+**Additional Context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
We want to encourage the use of the dedicated discussions space for questions and open-ended conversations. That will help keep the project's issues focused on bug reports and feature requests.