### PR TITLE
Don't have PR template comments span multiple paragraphs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
-<!--
-Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly.
+<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->
 
-Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request.
--->
+<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->
 
 # Checklist
 


### PR DESCRIPTION
I want to prevent possible issues with users adding the requested information on the blank line in between instruction paragraphs and accidentally having their content commented out.

<!--
Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly.

Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request.
-->

# Checklist

- [x] I have run `cargo xtask fixup` to automatically adhere to project formatting and style conventions
- [ ] I have made corresponding changes to the relevant documentation
- [ ] I have updated the `CHANGELOG.md` file in accordance with the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
- [ ] I have added tests to cover my changes
