### PR TITLE
Be more careful with conditional expressions on jobs

### DIFF
--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -83,6 +83,7 @@ githubActions: _#useMergeQueue & {
 		}
 
 		merge_queue: needs: [
+			"changes",
 			"cue_format",
 			"cue_synced",
 		]

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -30,7 +30,7 @@ rust: _#useMergeQueue & {
 			name: "format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
+			if:        "github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "rustfmt"},
@@ -46,7 +46,7 @@ rust: _#useMergeQueue & {
 			name: "lint"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'"
+			if:        "github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "clippy"},
@@ -71,7 +71,7 @@ rust: _#useMergeQueue & {
 				]
 			}
 			"runs-on": "${{ matrix.platform }}"
-			if:        "needs.changes.outputs.rust == 'true' && always()"
+			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -85,7 +85,7 @@ rust: _#useMergeQueue & {
 			name: "check / msrv"
 			needs: ["check", "format", "lint"]
 			"runs-on": defaultRunner
-			if:        "needs.changes.outputs.rust == 'true' && always()"
+			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				{
@@ -100,6 +100,7 @@ rust: _#useMergeQueue & {
 		}
 
 		merge_queue: needs: [
+			"changes",
 			"test_stable",
 			"check_msrv",
 		]

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -12,7 +12,7 @@ wordsmith: _#useMergeQueue & {
 			name: "markdown / format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request'"
+			if:        "github.event_name == 'pull_request' && needs.changes.outputs.markdown == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#prettier & {
@@ -35,6 +35,7 @@ wordsmith: _#useMergeQueue & {
 		}
 
 		merge_queue: needs: [
+			"changes",
 			"markdown_format",
 			"spellcheck",
 		]

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -117,11 +117,22 @@ jobs:
   merge_queue:
     name: github-actions workflow ready
     needs:
+      - changes
       - cue_format
       - cue_synced
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - name: 'Check status of job_id: changes'
+        run: |-
+          RESULT="${{ needs.changes.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
       - name: 'Check status of job_id: cue_format'
         run: |-
           RESULT="${{ needs.cue_format.result }}";

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -95,7 +95,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -128,7 +128,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.platform }}
-    if: needs.changes.outputs.rust == 'true' && always()
+    if: always() && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -158,7 +158,7 @@ jobs:
       - format
       - lint
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.rust == 'true' && always()
+    if: always() && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -179,11 +179,22 @@ jobs:
   merge_queue:
     name: rust workflow ready
     needs:
+      - changes
       - test_stable
       - check_msrv
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - name: 'Check status of job_id: changes'
+        run: |-
+          RESULT="${{ needs.changes.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
       - name: 'Check status of job_id: test_stable'
         run: |-
           RESULT="${{ needs.test_stable.result }}";

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.markdown == 'true' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.markdown == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -74,11 +74,22 @@ jobs:
   merge_queue:
     name: wordsmith workflow ready
     needs:
+      - changes
       - markdown_format
       - spellcheck
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - name: 'Check status of job_id: changes'
+        run: |-
+          RESULT="${{ needs.changes.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
       - name: 'Check status of job_id: markdown_format'
         run: |-
           RESULT="${{ needs.markdown_format.result }}";


### PR DESCRIPTION
When you use `jobs.<job_id>.needs`:

> If a job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue.

There was a situation where the `changes` job failed, which skipped the markdown_format/spellcheck jobs even though they should have been run. We need to make sure that when we're using `if:` conditional expressions, that we fail the workflow appropriately.

![image](https://github.com/EarthmanMuons/rustops-blueprint/assets/4742/6d511f17-468c-4ac0-893a-07adb25ec6bd)

I tried **really** hard to have CUE generate all job names aside from the merge_queue job itself so we wouldn't have to manage any manual list, but I kept hitting constant issues due to the GitHub JSONSchema.

```cue
let allJobIds = [ for k, _ in jobs if k != "merge_queue" {k}]
```

I'm trying this alternative of just making sure that `changes` actually succeeded, since that's what the other jobs end up referencing.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
- https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
