### PR TITLE
Add xtask to generate and open an HTML code coverage report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,24 +76,28 @@ git remote add upstream https://github.com/EarthmanMuons/rustops-blueprint.git
 ### Install Rust Dependencies
 
 The project is developed using the latest stable release of Rust, but it also
-requires a couple of additional toolchain [components][]. We use the lint tool
-`clippy` for extra checks on common mistakes and stylistic choices, as well as
-`rustfmt` for automatic code formatting.
+requires a few additional toolchain [components][]. We use the lint tool
+[`clippy`][] for extra checks on common mistakes and stylistic choices,
+[`llvm-tools-preview`][] to process coverage data and generate reports, as well
+as [`rustfmt`][] for automatic code formatting.
 
-Additionally, our project utilizes [`cargo-insta`][] for snapshot testing, and
-we recommend [`cargo-nextest`][] as an enhanced test runner. It displays each
-test's execution time by default, and can help to identify performance outliers
-in the test suite.
+Additionally, our project utilizes [`grcov`][] to aggregate code coverage data,
+[`cargo-insta`][] for snapshot testing, and we recommend [`cargo-nextest`][] as
+an enhanced test runner. It displays each test's execution time by default, and
+can help to identify performance outliers in the test suite.
 
 [components]: https://rust-lang.github.io/rustup/concepts/components.html
+[`clippy`]: https://doc.rust-lang.org/clippy/
+[`llvm-tools-preview`]: https://github.com/rust-lang/rust/issues/85658
+[`rustfmt`]: https://github.com/rust-lang/rustfmt
+[`grcov`]: https://github.com/mozilla/grcov
 [`cargo-insta`]: https://insta.rs/
 [`cargo-nextest`]: https://nexte.st/
 
 #### Automated Installation
 
 We've provided an xtask script to automatically install all required toolchain
-components and cargo dependencies. To use this, simply run the following
-command:
+components and cargo dependencies. To use this, run the following command:
 
 ```
 cargo xtask install
@@ -107,13 +111,13 @@ the installation process, follow these steps:
 1. Install the required toolchain components:
 
    ```
-   rustup component add clippy rustfmt
+   rustup component add clippy llvm-tools-preview rustfmt
    ```
 
-2. Install the cargo dependencies:
+2. Install the required cargo dependencies:
 
    ```
-   cargo install cargo-insta cargo-nextest
+   cargo install grcov cargo-insta cargo-nextest
    ```
 
 ### Install Additional Tools
@@ -122,10 +126,13 @@ To maintain consistency and avoid bikeshedding, our project also uses automated
 tools to enforce formatting and style conventions for non-Rust files. Ensure
 that you have the following tools installed:
 
-- [codespell](https://github.com/codespell-project/codespell) for spell checking
-  all files
-- [CUE](https://cuelang.org/) for generating and validating YAML files
-- [Prettier](https://prettier.io/) for formatting Markdown files
+- [codespell][] for spell checking all files
+- [CUE][] for generating and validating YAML files
+- [Prettier][] for formatting Markdown files
+
+[codespell]: https://github.com/codespell-project/codespell
+[CUE]: https://cuelang.org/
+[Prettier]: https://prettier.io/
 
 ## Contribution Guidelines
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "lexopt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +67,28 @@ dependencies = [
 [[package]]
 name = "mylib"
 version = "0.1.0"
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "open"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16814a067484415fda653868c9be0ac5f2abd2ef5d951082a5f2fe1b3662944"
+dependencies = [
+ "is-wsl",
+ "pathdiff",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "ppv-lite86"
@@ -112,5 +153,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lexopt",
+ "open",
  "xshell",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,4 +11,5 @@ publish = false
 [dependencies]
 anyhow = "1.0.71"
 lexopt = "0.3.0"
+open = "4.1.0"
 xshell = "0.2.2"

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,0 +1,41 @@
+use anyhow::{Context, Result};
+use xshell::{cmd, Shell};
+
+use crate::utils::{project_root, verbose_cd};
+
+pub fn html_report() -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+
+    let temp_dir = sh.create_temp_dir().context("allocating temp_dir")?;
+    let temp_dir_path = temp_dir.path();
+
+    cmd!(sh, "cargo test --tests")
+        .env("CARGO_INCREMENTAL", "0")
+        .env("RUSTFLAGS", "-C instrument-coverage")
+        .env(
+            "LLVM_PROFILE_FILE",
+            temp_dir_path.join("default_%m_%p.profraw"),
+        )
+        .run()?;
+
+    let options = [
+        "--binary-path",
+        "./target/debug/",
+        "--output-types",
+        "html",
+        "--output-path",
+        "./target/debug/coverage/",
+        "--source-dir",
+        ".",
+        "--ignore-not-existing",
+        "--branch",
+    ];
+    cmd!(sh, "grcov {options...} {temp_dir_path}").run()?;
+
+    let report = project_root().join("target/debug/coverage/index.html");
+    eprintln!("Opening {}", report.display());
+    open::that(report).context("opening coverage report")?;
+
+    Ok(())
+}

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -5,10 +5,9 @@ use crate::utils::{project_root, verbose_cd};
 
 pub fn rust_dependencies() -> Result<()> {
     let sh = Shell::new()?;
-    let root = project_root();
-    verbose_cd(&sh, &root);
+    verbose_cd(&sh, project_root());
 
-    cmd!(sh, "rustup component add clippy rustfmt").run()?;
-    cmd!(sh, "cargo install cargo-insta cargo-nextest").run()?;
+    cmd!(sh, "rustup component add clippy llvm-tools-preview rustfmt").run()?;
+    cmd!(sh, "cargo install cargo-insta cargo-nextest grcov").run()?;
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use anyhow::Result;
 
+mod coverage;
 mod fixup;
 mod install;
 mod utils;
@@ -15,12 +16,13 @@ SYNOPSIS
     cargo xtask [COMMAND...]
 
 COMMANDS
+    coverage               Generate and open an HTML code coverage report.
     fixup                  Run all fixup xtasks, editing files in-place.
     fixup.github-actions   Format CUE files in-place and regenerate CI YAML files.
     fixup.markdown         Format Markdown files in-place.
     fixup.rust             Fix lints and format Rust files in-place.
     fixup.spelling         Fix common misspellings across all files in-place.
-    install                Install required Rust components and cargo dependencies
+    install                Install required Rust components and cargo dependencies.
 ";
 
 fn main() -> Result<()> {
@@ -42,6 +44,7 @@ fn main() -> Result<()> {
             Value(value) => {
                 let value = value.string()?;
                 match value.as_str() {
+                    "coverage" => coverage::html_report()?,
                     "fixup" => fixup::everything()?,
                     "fixup.github-actions" => fixup::github_actions()?,
                     "fixup.markdown" => fixup::markdown()?,


### PR DESCRIPTION
We'll add `lcov` format reports and uploading to a coverage provider later.

See:
- https://doc.rust-lang.org/rustc/instrument-coverage.html
- https://github.com/mozilla/grcov#generate-a-coverage-report-from-coverage-artifacts
- https://blog.rng0.io/how-to-do-code-coverage-in-rust

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
