### PR TITLE
Ignore the xtask code when generating coverage report

### DIFF
--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -1,10 +1,9 @@
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use xshell::{cmd, Shell};
 
-use crate::utils::{project_root, verbose_cd};
+use crate::utils::{find_files, project_root, verbose_cd};
 
 pub fn everything() -> Result<()> {
     spelling()?; // affects all file types; run this first
@@ -28,35 +27,14 @@ pub fn markdown() -> Result<()> {
 
 fn format_markdown() -> Result<()> {
     let sh = Shell::new()?;
-    let root = project_root();
-    verbose_cd(&sh, &root);
+    verbose_cd(&sh, project_root());
 
-    let markdown_files = find_markdown_files(sh.current_dir())?;
-    let relative_paths: Vec<PathBuf> = markdown_files
-        .into_iter()
-        .filter_map(|path| path.strip_prefix(&root).ok().map(PathBuf::from))
-        .collect();
-
+    let markdown_files = find_files(sh.current_dir(), "md")?;
     cmd!(sh, "prettier --prose-wrap always --write")
-        .args(&relative_paths)
+        .args(markdown_files)
         .run()?;
 
     Ok(())
-}
-
-fn find_markdown_files<P: AsRef<Path>>(dir: P) -> Result<Vec<PathBuf>> {
-    let mut result = Vec::new();
-    for entry in fs::read_dir(dir)? {
-        let path = entry?.path();
-
-        if path.is_dir() {
-            let mut subdir_files = find_markdown_files(&path)?;
-            result.append(&mut subdir_files);
-        } else if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
-            result.push(path);
-        }
-    }
-    Ok(result)
 }
 
 pub fn rust() -> Result<()> {

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,6 +1,34 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
 use xshell::Shell;
+
+pub(crate) fn find_files<P: AsRef<Path>>(dir: P, extension: &str) -> Result<Vec<PathBuf>> {
+    let mut result = Vec::new();
+    let dir_path = dir.as_ref();
+    find_files_recursive(dir_path, extension, &mut result)?;
+
+    let relative_paths: Vec<PathBuf> = result
+        .into_iter()
+        .filter_map(|path| path.strip_prefix(dir_path).ok().map(PathBuf::from))
+        .collect();
+
+    Ok(relative_paths)
+}
+
+fn find_files_recursive(dir: &Path, extension: &str, result: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+
+        if path.is_dir() {
+            find_files_recursive(&path, extension, result)?;
+        } else if path.is_file() && path.extension().map_or(false, |ext| ext == extension) {
+            result.push(path);
+        }
+    }
+    Ok(())
+}
 
 pub(crate) fn project_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
In order to have `grcov` properly ignore certain packages, the LLVM profile files must exist within the project directory structure, so we can't use our temp_dir trick to keep things clean. Instead, I've made the `find_markdown_files` function generic so you can just supply the desired extension as an argument, and the returned paths will automatically be made relative to the given directory.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
