### PR TITLE
Don't shell out for removing files

### DIFF
--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use anyhow::{Context, Result};
 use xshell::{cmd, Shell};
 
@@ -32,7 +34,9 @@ pub fn html_report() -> Result<()> {
     let profile_files = find_files(sh.current_dir(), "profraw")?;
     if !profile_files.is_empty() {
         eprintln!("Cleaning up LLVM profile files");
-        cmd!(sh, "rm").args(profile_files).run()?;
+        for file in profile_files {
+            fs::remove_file(&file)?;
+        }
     }
 
     let report = project_root().join("target/debug/coverage/index.html");

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use xshell::{cmd, Shell};
 
-use crate::utils::{find_files, project_root, verbose_cd};
+use crate::utils::{find_files, project_root, to_relative_paths, verbose_cd};
 
 pub fn everything() -> Result<()> {
     spelling()?; // affects all file types; run this first
@@ -30,8 +30,9 @@ fn format_markdown() -> Result<()> {
     verbose_cd(&sh, project_root());
 
     let markdown_files = find_files(sh.current_dir(), "md")?;
+    let relative_paths = to_relative_paths(markdown_files, sh.current_dir());
     cmd!(sh, "prettier --prose-wrap always --write")
-        .args(markdown_files)
+        .args(relative_paths)
         .run()?;
 
     Ok(())

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -8,13 +8,7 @@ pub(crate) fn find_files<P: AsRef<Path>>(dir: P, extension: &str) -> Result<Vec<
     let mut result = Vec::new();
     let dir_path = dir.as_ref();
     find_files_recursive(dir_path, extension, &mut result)?;
-
-    let relative_paths: Vec<PathBuf> = result
-        .into_iter()
-        .filter_map(|path| path.strip_prefix(dir_path).ok().map(PathBuf::from))
-        .collect();
-
-    Ok(relative_paths)
+    Ok(result)
 }
 
 fn find_files_recursive(dir: &Path, extension: &str, result: &mut Vec<PathBuf>) -> Result<()> {
@@ -35,6 +29,14 @@ pub(crate) fn project_root() -> PathBuf {
         .parent()
         .expect("Failed to find project root")
         .to_path_buf()
+}
+
+pub(crate) fn to_relative_paths<P: AsRef<Path>>(paths: Vec<PathBuf>, base_dir: P) -> Vec<PathBuf> {
+    let base_path = base_dir.as_ref();
+    paths
+        .into_iter()
+        .filter_map(|path| path.strip_prefix(base_path).ok().map(PathBuf::from))
+        .collect()
 }
 
 pub(crate) fn verbose_cd<P: AsRef<Path>>(sh: &Shell, dir: P) {


### PR DESCRIPTION
Using Rust's `std::fs::remove_file` function should be safer and platform-independent. Since I am not going to display the paths to the files we're removing and want to eliminate the shell's current directory from the equation, I split out the relative_paths functionality into a dedicated function, so we can get either absolute or relative as necessary.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
