### PR TITLE
Show module structure integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,12 +61,14 @@ name = "mybin"
 version = "0.1.0"
 dependencies = [
  "mylib",
- "rand",
 ]
 
 [[package]]
 name = "mylib"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "once_cell"

--- a/crates/mybin/Cargo.toml
+++ b/crates/mybin/Cargo.toml
@@ -15,4 +15,3 @@ license.workspace = true
 
 [dependencies]
 mylib = { path = "../mylib" }
-rand = "0.8.5"

--- a/crates/mybin/src/main.rs
+++ b/crates/mybin/src/main.rs
@@ -1,17 +1,12 @@
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use mylib::{add, shuffle_array};
 
 fn main() {
     let left = 10;
     let right = 32;
-    println!(
-        "Hello, world! {left} plus {right} is {}!",
-        mylib::add(left, right)
-    );
+    println!("Hello, world! {left} plus {right} is {}!", add(left, right));
 
-    let mut rng = thread_rng();
     let mut nums = [1, 2, 3, 4, 5];
     println!("Unshuffled: {:?}", nums);
-    nums.shuffle(&mut rng);
+    shuffle_array(&mut nums);
     println!("Shuffled:   {:?}", nums);
 }

--- a/crates/mylib/Cargo.toml
+++ b/crates/mylib/Cargo.toml
@@ -14,3 +14,4 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.8.5"

--- a/crates/mylib/src/lib.rs
+++ b/crates/mylib/src/lib.rs
@@ -1,5 +1,12 @@
+use rand::seq::SliceRandom;
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
+}
+
+pub fn shuffle_array(nums: &mut [i32]) {
+    let mut rng = rand::thread_rng();
+    nums.shuffle(&mut rng);
 }
 
 #[cfg(test)]
@@ -7,8 +14,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_add() {
+        assert_eq!(add(10, 32), 42);
     }
 }

--- a/crates/mylib/tests/integration/main.rs
+++ b/crates/mylib/tests/integration/main.rs
@@ -1,0 +1,13 @@
+use mylib::shuffle_array;
+
+#[test]
+fn test_shuffle_array() {
+    let mut nums = [1, 2, 3, 4, 5];
+    let original = nums;
+    shuffle_array(&mut nums);
+
+    assert_eq!(nums.len(), original.len());
+    for num in original.iter() {
+        assert!(nums.contains(num));
+    }
+}


### PR DESCRIPTION
This is a trivial example of how to structure integration tests for mylib. It's not super realistic, but it's just there for demonstration.

I'm holding off on moving the unit tests module into a dedicated file...it is common to see on larger crates, and cargo can avoid unnecessary compilation depending on which file was changed, but it's a bit of premature optimization? I'll have to think about it some more.

See:
- https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
