### PR TITLE
Add CI job to run tests using Miri

### DIFF
--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -23,22 +23,46 @@ scheduled: {
 		RUSTFLAGS:         "-D warnings"
 	}
 
-	jobs: direct_minimal_versions: {
-		name:      "direct-minimal-versions / stable"
-		"runs-on": defaultRunner
-		steps: [
-			_#checkoutCode,
-			_#installRust,
-			_#installRust & {with: toolchain: "nightly"},
-			{
-				name: "Default to stable Rust"
-				run:  "rustup default stable"
-			},
-			{
-				name: "Resolve minimal dependency versions instead of maximum"
-				run:  "cargo +nightly update -Z direct-minimal-versions"
-			},
-			for step in _testRust {step},
-		]
+	jobs: {
+		direct_minimal_versions: {
+			name:      "direct-minimal-versions / stable"
+			"runs-on": defaultRunner
+			steps: [
+				_#checkoutCode,
+				_#installRust,
+				_#installRust & {with: toolchain: "nightly"},
+				{
+					name: "Default to stable Rust"
+					run:  "rustup default stable"
+				},
+				{
+					name: "Resolve minimal dependency versions instead of maximum"
+					run:  "cargo +nightly update -Z direct-minimal-versions"
+				},
+				for step in _testRust {step},
+			]
+		}
+
+		// https://github.com/rust-lang/miri
+		// Detect certain classes of undefined behavior.
+		miri: {
+			name:      "test / miri"
+			"runs-on": defaultRunner
+			steps: [
+				_#checkoutCode,
+				_#installRust & {with: {
+					toolchain:  "nightly"
+					components: "miri"
+				}},
+				{
+					name: "Setup Miri environment"
+					run:  "cargo miri setup"
+				},
+				{
+					name: "Run tests with Miri"
+					run:  "cargo miri test"
+				},
+			]
+		}
 	}
 }

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -42,3 +42,18 @@ jobs:
         run: cargo nextest run --locked --all-targets --all-features
       - name: Run doctests
         run: cargo test --locked --doc
+  miri:
+    name: test / miri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: nightly
+          components: miri
+      - name: Setup Miri environment
+        run: cargo miri setup
+      - name: Run tests with Miri
+        run: cargo miri test


### PR DESCRIPTION
Miri is an experimental interpreter that can detect certain classes of undefined behavior.

See:
- https://github.com/rust-lang/miri

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
