### PR TITLE
Use direct-minimal-versions as part of MSRV job

### DIFF
--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -24,25 +24,6 @@ scheduled: {
 	}
 
 	jobs: {
-		direct_minimal_versions: {
-			name:      "direct-minimal-versions / stable"
-			"runs-on": defaultRunner
-			steps: [
-				_#checkoutCode,
-				_#installRust,
-				_#installRust & {with: toolchain: "nightly"},
-				{
-					name: "Default to stable Rust"
-					run:  "rustup default stable"
-				},
-				{
-					name: "Resolve minimal dependency versions instead of maximum"
-					run:  "cargo +nightly update -Z direct-minimal-versions"
-				},
-				for step in _testRust {step},
-			]
-		}
-
 		// https://github.com/rust-lang/miri
 		// Detect certain classes of undefined behavior.
 		miri: {

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,8 +151,8 @@ jobs:
         run: cargo nextest run --locked --all-targets --all-features
       - name: Run doctests
         run: cargo test --locked --doc
-  check_msrv:
-    name: check / msrv
+  test_msrv:
+    name: test / msrv
     needs:
       - check
       - format
@@ -169,19 +169,35 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: nightly
+      - name: Resolve minimal dependency versions instead of maximum
+        run: cargo +nightly update -Z direct-minimal-versions
+      - name: Default to MSRV Rust
+        run: rustup default ${{ steps.msrv.outputs.version }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01
         with:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
-      - name: Check packages and dependencies for errors
-        run: cargo check --locked --all-targets --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@97bdefc2d9c284a0a0e620f6d484dd156d256e81
+        with:
+          tool: cargo-nextest
+      - name: Compile tests
+        run: cargo test --locked --no-run
+      - name: Run tests
+        run: cargo nextest run --locked --all-targets --all-features
+      - name: Run doctests
+        run: cargo test --locked --doc
   merge_queue:
     name: rust workflow ready
     needs:
       - changes
       - test_stable
-      - check_msrv
+      - test_msrv
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -205,9 +221,9 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: check_msrv'
+      - name: 'Check status of job_id: test_msrv'
         run: |-
-          RESULT="${{ needs.check_msrv.result }}";
+          RESULT="${{ needs.test_msrv.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,34 +14,6 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
 jobs:
-  direct_minimal_versions:
-    name: direct-minimal-versions / stable
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
-        with:
-          toolchain: stable
-      - name: Install nightly Rust toolchain
-        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
-        with:
-          toolchain: nightly
-      - name: Default to stable Rust
-        run: rustup default stable
-      - name: Resolve minimal dependency versions instead of maximum
-        run: cargo +nightly update -Z direct-minimal-versions
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@97bdefc2d9c284a0a0e620f6d484dd156d256e81
-        with:
-          tool: cargo-nextest
-      - name: Compile tests
-        run: cargo test --locked --no-run
-      - name: Run tests
-        run: cargo nextest run --locked --all-targets --all-features
-      - name: Run doctests
-        run: cargo test --locked --doc
   miri:
     name: test / miri
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to reliably test MSRV by ensuring that the lower-bounds for dependencies are correct, rather than testing the MSRV Rust version and minimal cargo dependency versions separately.

See:
- https://github.com/rust-lang/cargo/issues/5657

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
