### PR TITLE
Add separate step to compile Miri tests

### DIFF
--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -40,6 +40,10 @@ scheduled: {
 					run:  "cargo miri setup"
 				},
 				{
+					name: "Compile tests with Miri"
+					run:  "cargo miri test --no-run"
+				},
+				{
 					name: "Run tests with Miri"
 					run:  "cargo miri test"
 				},

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -27,5 +27,7 @@ jobs:
           components: miri
       - name: Setup Miri environment
         run: cargo miri setup
+      - name: Compile tests with Miri
+        run: cargo miri test --no-run
       - name: Run tests with Miri
         run: cargo miri test


### PR DESCRIPTION
This makes timing easier to compare across runs since you can account for compilation versus the test runs themselves. Note that I'm not going to add `cargo-nextest` into the mix because it prevents Miri from being able to detect data races where two tests race on a shared resource. This is a scheduled job anyway, so speed is less of a concern.

See:
- https://github.com/rust-lang/miri#running-tests-in-parallel

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
