### PR TITLE
Switch from grcov to cargo-llvm-cov

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,22 +76,20 @@ git remote add upstream https://github.com/EarthmanMuons/rustops-blueprint.git
 ### Install Rust Dependencies
 
 The project is developed using the latest stable release of Rust, but it also
-requires a few additional toolchain [components][]. We use the lint tool
-[`clippy`][] for extra checks on common mistakes and stylistic choices,
-[`llvm-tools-preview`][] to process coverage data and generate reports, as well
+requires a couple of additional toolchain [components][]. We use the lint tool
+[`clippy`][] for extra checks on common mistakes and stylistic choices, as well
 as [`rustfmt`][] for automatic code formatting.
 
-Additionally, our project utilizes [`grcov`][] to aggregate code coverage data,
-[`cargo-insta`][] for snapshot testing, and we recommend [`cargo-nextest`][] as
-an enhanced test runner. It displays each test's execution time by default, and
-can help to identify performance outliers in the test suite.
+Additionally, our project utilizes [`cargo-insta`][] for snapshot testing,
+[`cargo-llvm-cov`][] to generate code coverage reports, and [`cargo-nextest`][]
+as an enhanced test runner. It displays each test's execution time by default,
+and can help to identify performance outliers in the test suite.
 
 [components]: https://rust-lang.github.io/rustup/concepts/components.html
 [`clippy`]: https://doc.rust-lang.org/clippy/
-[`llvm-tools-preview`]: https://github.com/rust-lang/rust/issues/85658
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
-[`grcov`]: https://github.com/mozilla/grcov
 [`cargo-insta`]: https://insta.rs/
+[`cargo-llvm-cov`]: https://github.com/taiki-e/cargo-llvm-cov
 [`cargo-nextest`]: https://nexte.st/
 
 #### Automated Installation
@@ -111,13 +109,13 @@ the installation process, follow these steps:
 1. Install the required toolchain components:
 
    ```
-   rustup component add clippy llvm-tools-preview rustfmt
+   rustup component add clippy rustfmt
    ```
 
 2. Install the required cargo dependencies:
 
    ```
-   cargo install grcov cargo-insta cargo-nextest
+   cargo install cargo-insta cargo-llvm-cov cargo-nextest
    ```
 
 ### Install Additional Tools
@@ -235,6 +233,14 @@ commands by running:
 ```
 cargo xtask --help
 ```
+
+For example:
+
+- Generate and open an HTML code coverage report
+
+  ```
+  cargo xtask coverage.html
+  ```
 
 [xtask]: https://github.com/matklad/cargo-xtask
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,25 +26,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "lexopt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +33,9 @@ checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "mybin"
@@ -69,28 +50,6 @@ version = "0.1.0"
 dependencies = [
  "rand",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "open"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16814a067484415fda653868c9be0ac5f2abd2ef5d951082a5f2fe1b3662944"
-dependencies = [
- "is-wsl",
- "pathdiff",
-]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "ppv-lite86"
@@ -155,6 +114,5 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lexopt",
- "open",
  "xshell",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,5 +11,4 @@ publish = false
 [dependencies]
 anyhow = "1.0.71"
 lexopt = "0.3.0"
-open = "4.1.0"
 xshell = "0.2.2"

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,46 +1,22 @@
-use std::fs;
-
-use anyhow::{Context, Result};
+use anyhow::Result;
 use xshell::{cmd, Shell};
 
-use crate::utils::{find_files, project_root, verbose_cd};
+use crate::utils::{project_root, verbose_cd};
 
 pub fn html_report() -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
+    cmd!(
+        sh,
+        "cargo llvm-cov nextest --ignore-filename-regex xtask --open"
+    )
+    .run()?;
+    Ok(())
+}
 
-    cmd!(sh, "cargo test --tests")
-        .env("CARGO_INCREMENTAL", "0")
-        .env("RUSTFLAGS", "-C instrument-coverage")
-        .env("LLVM_PROFILE_FILE", "default_%m_%p.profraw")
-        .run()?;
-
-    let options = [
-        "--binary-path",
-        "./target/debug/",
-        "--output-types",
-        "html",
-        "--output-path",
-        "./target/debug/coverage/",
-        "--source-dir",
-        ".",
-        "--ignore-not-existing",
-        "--ignore",
-        "xtask/*",
-        "--branch",
-    ];
-    cmd!(sh, "grcov {options...} .").run()?;
-
-    let profile_files = find_files(sh.current_dir(), "profraw")?;
-    if !profile_files.is_empty() {
-        eprintln!("Cleaning up LLVM profile files");
-        for file in profile_files {
-            fs::remove_file(&file)?;
-        }
-    }
-
-    let report = project_root().join("target/debug/coverage/index.html");
-    eprintln!("Opening {}", report.display());
-    open::that(report).context("opening coverage report")?;
+pub fn report_summary() -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+    cmd!(sh, "cargo llvm-cov nextest --ignore-filename-regex xtask").run()?;
     Ok(())
 }

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -7,7 +7,7 @@ pub fn rust_dependencies() -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 
-    cmd!(sh, "rustup component add clippy llvm-tools-preview rustfmt").run()?;
-    cmd!(sh, "cargo install cargo-insta cargo-nextest grcov").run()?;
+    cmd!(sh, "rustup component add clippy rustfmt").run()?;
+    cmd!(sh, "cargo install cargo-insta cargo-llvm-cov cargo-nextest").run()?;
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,7 +16,8 @@ SYNOPSIS
     cargo xtask [COMMAND...]
 
 COMMANDS
-    coverage               Generate and open an HTML code coverage report.
+    coverage               Generate and print a code coverage report summary.
+    coverage.html          Generate and open an HTML code coverage report.
     fixup                  Run all fixup xtasks, editing files in-place.
     fixup.github-actions   Format CUE files in-place and regenerate CI YAML files.
     fixup.markdown         Format Markdown files in-place.
@@ -44,7 +45,8 @@ fn main() -> Result<()> {
             Value(value) => {
                 let value = value.string()?;
                 match value.as_str() {
-                    "coverage" => coverage::html_report()?,
+                    "coverage" => coverage::report_summary()?,
+                    "coverage.html" => coverage::html_report()?,
                     "fixup" => fixup::everything()?,
                     "fixup.github-actions" => fixup::github_actions()?,
                     "fixup.markdown" => fixup::markdown()?,


### PR DESCRIPTION
This tool provides a much better workflow compared to what we were doing with our grcov-based xtask. It's well-written, popular, and receives regular maintenance, so it should be easier to keep on top of upstream changes. It will also be trivial to add publishing to codecov.

See:
- https://github.com/taiki-e/cargo-llvm-cov

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
