### PR TITLE
Run actionlint on GitHub Actions workflow files

### DIFF
--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -82,10 +82,20 @@ githubActions: _#useMergeQueue & {
 			]
 		}
 
+		lint: {
+			name: "lint"
+			needs: ["cue_synced"]
+			"runs-on": defaultRunner
+			steps: [
+				_#checkoutCode,
+				_#actionlint,
+			]
+		}
+
 		merge_queue: needs: [
 			"changes",
 			"cue_format",
-			"cue_synced",
+			"lint",
 		]
 	}
 }

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -60,7 +60,7 @@ rust: _#useMergeQueue & {
 
 		test_stable: {
 			name: "test / stable"
-			needs: ["check", "format", "lint"]
+			needs: ["changes", "check", "format", "lint"]
 			defaults: run: shell: "bash"
 			strategy: {
 				"fail-fast": false
@@ -83,7 +83,7 @@ rust: _#useMergeQueue & {
 		// Minimum Supported Rust Version
 		test_msrv: {
 			name: "test / msrv"
-			needs: ["check", "format", "lint"]
+			needs: ["changes", "check", "format", "lint"]
 			"runs-on": defaultRunner
 			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -15,6 +15,12 @@ _sha1: =~"^[0-9a-fA-F]{40}$"
 // all third-party actions must be pinned to a specific commit id
 _#step: uses?: #pinned
 
+// https://github.com/raven-actions/actionlint/releases
+_#actionlint: _#step & {
+	name: "Check lints"
+	uses: "raven-actions/actionlint@a143169aa718a5c056297c13a123fa1fb0cb6040"
+}
+
 // https://github.com/Swatinem/rust-cache/releases
 _#cacheRust: _#step & {
 	name: "Cache dependencies"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -114,12 +114,22 @@ jobs:
               echo "Run 'cargo xtask fixup.github-actions' locally to regenerate the YAML from CUE."
               exit 1
           fi
+  lint:
+    name: lint
+    needs:
+      - cue_synced
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Check lints
+        uses: raven-actions/actionlint@a143169aa718a5c056297c13a123fa1fb0cb6040
   merge_queue:
     name: github-actions workflow ready
     needs:
       - changes
       - cue_format
-      - cue_synced
+      - lint
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -143,9 +153,9 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: cue_synced'
+      - name: 'Check status of job_id: lint'
         run: |-
-          RESULT="${{ needs.cue_synced.result }}";
+          RESULT="${{ needs.lint.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,6 +114,7 @@ jobs:
   test_stable:
     name: test / stable
     needs:
+      - changes
       - check
       - format
       - lint
@@ -154,6 +155,7 @@ jobs:
   test_msrv:
     name: test / msrv
     needs:
+      - changes
       - check
       - format
       - lint


### PR DESCRIPTION
I expect this to fail, as I ran it locally. It caught a quoting issue on our `awk` command (via shellcheck) and also pointed out two references to `needs.changes.outputs.rust` that aren't valid. I'll fix those shortly, but wanted to see how this runs in CI before pushing forward.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
