### PR TITLE
Add --ignore-missing option flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "lexopt"
@@ -50,6 +62,12 @@ version = "0.1.0"
 dependencies = [
  "rand",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "ppv-lite86"
@@ -94,6 +112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "xshell"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +142,8 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "is_ci",
  "lexopt",
+ "which",
  "xshell",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,5 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.71"
+is_ci = "1.1.1"
 lexopt = "0.3.0"
+which = "4.4.0"
 xshell = "0.2.2"

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use which::which;
+use xshell::{cmd, Cmd, Shell};
+
+use crate::Config;
+
+pub(crate) fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    create_cmd(
+        "cargo",
+        "https://www.rust-lang.org/learn/get-started",
+        config,
+        sh,
+    )
+}
+
+pub(crate) fn codespell_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    create_cmd(
+        "codespell",
+        "https://github.com/codespell-project/codespell",
+        config,
+        sh,
+    )
+}
+
+pub(crate) fn cue_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    create_cmd("cue", "https://cuelang.org/", config, sh)
+}
+
+pub(crate) fn prettier_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    create_cmd("prettier", "https://prettier.io", config, sh)
+}
+
+fn create_cmd<'a>(
+    cmd_name: &str,
+    install_url: &str,
+    config: &Config,
+    sh: &'a Shell,
+) -> Result<Option<Cmd<'a>>> {
+    if check_command(cmd_name, install_url, config).is_err() {
+        return Ok(None);
+    }
+
+    let cmd = cmd!(sh, "{cmd_name}");
+
+    Ok(Some(cmd))
+}
+
+fn check_command(cmd_name: &str, install_url: &str, config: &Config) -> Result<()> {
+    // only ignore missing commands when not running in a CI environment
+    let is_local = !is_ci::cached();
+    match which(cmd_name) {
+        Ok(_) => {
+            // the command exists, we're good
+            Ok(())
+        }
+        Err(_) if config.ignore_missing_commands && is_local => {
+            println!("Warning: command not found `{}`", cmd_name);
+            println!("Install: {}", install_url);
+            Err(anyhow::Error::msg("command is missing, but ignored"))
+        }
+        Err(_) if is_ci::cached() => {
+            println!("Error: command not found `{}`", cmd_name);
+            println!("Install: {}", install_url);
+            std::process::exit(1);
+        }
+        Err(_) => {
+            println!(
+                "Error: command not found `{}`; skip this task with --ignore-missing",
+                cmd_name
+            );
+            println!("Install: {}", install_url);
+            std::process::exit(1);
+        }
+    }
+}

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 use xshell::{cmd, Shell};
 
 use crate::utils::{project_root, verbose_cd};
+use crate::Config;
 
-pub fn html_report() -> Result<()> {
+pub fn html_report(_config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
     cmd!(
@@ -14,7 +15,7 @@ pub fn html_report() -> Result<()> {
     Ok(())
 }
 
-pub fn report_summary() -> Result<()> {
+pub fn report_summary(_config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
     cmd!(sh, "cargo llvm-cov nextest --ignore-filename-regex xtask").run()?;

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -1,81 +1,97 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use xshell::{cmd, Shell};
+use xshell::Shell;
 
+use crate::commands::{cargo_cmd, codespell_cmd, cue_cmd, prettier_cmd};
 use crate::utils::{find_files, project_root, to_relative_paths, verbose_cd};
+use crate::Config;
 
-pub fn everything() -> Result<()> {
-    spelling()?; // affects all file types; run this first
-    github_actions()?;
-    markdown()?;
-    rust()?;
+pub fn everything(config: &Config) -> Result<()> {
+    spelling(config)?; // affects all file types; run this first
+    github_actions(config)?;
+    markdown(config)?;
+    rust(config)?;
     Ok(())
 }
 
-pub fn spelling() -> Result<()> {
-    let sh = Shell::new()?;
-    verbose_cd(&sh, project_root());
-    cmd!(sh, "codespell --write-changes").run()?;
-    Ok(())
-}
-
-pub fn markdown() -> Result<()> {
-    format_markdown()?;
-    Ok(())
-}
-
-fn format_markdown() -> Result<()> {
+pub fn spelling(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 
-    let markdown_files = find_files(sh.current_dir(), "md")?;
-    let relative_paths = to_relative_paths(markdown_files, sh.current_dir());
-    cmd!(sh, "prettier --prose-wrap always --write")
-        .args(relative_paths)
-        .run()?;
+    let cmd_option = codespell_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["--write-changes"];
+        cmd.args(args).run()?;
+    }
 
     Ok(())
 }
 
-pub fn rust() -> Result<()> {
-    lint_rust()?;
-    format_rust()?;
+pub fn github_actions(config: &Config) -> Result<()> {
+    lint_cue(config)?;
+    format_cue(config)?;
+    regenerate_ci_yaml(config)?;
     Ok(())
 }
 
-fn lint_rust() -> Result<()> {
+pub fn markdown(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
-    cmd!(
-        sh,
-        "cargo fix --allow-no-vcs --all-features --edition-idioms"
-    )
-    .run()?;
-    cmd!(
-        sh,
-        "cargo clippy --all-targets --all-features --fix --allow-no-vcs"
-    )
-    .run()?;
-    cmd!(
-        sh,
-        "cargo clippy --all-targets --all-features -- -D warnings"
-    )
-    .run()?;
+
+    let cmd_option = prettier_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["--prose-wrap", "always", "--write"];
+        let markdown_files = find_files(sh.current_dir(), "md")?;
+        let relative_paths = to_relative_paths(markdown_files, sh.current_dir());
+        cmd.args(args).args(relative_paths).run()?;
+    }
+
     Ok(())
 }
 
-fn format_rust() -> Result<()> {
+pub fn rust(config: &Config) -> Result<()> {
+    lint_rust(config)?;
+    format_rust(config)?;
+    Ok(())
+}
+
+fn lint_cue(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
-    verbose_cd(&sh, project_root());
-    cmd!(sh, "cargo fmt").run()?;
+    verbose_cd(&sh, cue_dir());
+
+    let cmd_option = cue_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["vet", "--concrete"];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }
 
-pub fn github_actions() -> Result<()> {
-    lint_cue()?;
-    format_cue()?;
-    regenerate_ci_yaml()?;
+fn format_cue(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, cue_dir());
+
+    let cmd_option = cue_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["fmt", "--simplify"];
+        cmd.args(args).run()?;
+    }
+
+    Ok(())
+}
+
+fn regenerate_ci_yaml(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, cue_dir());
+
+    let cmd_option = cue_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["cmd", "regen-ci-yaml"];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }
 
@@ -83,23 +99,52 @@ fn cue_dir() -> PathBuf {
     project_root().join(".github/cue")
 }
 
-fn lint_cue() -> Result<()> {
+fn lint_rust(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
-    verbose_cd(&sh, cue_dir());
-    cmd!(sh, "cue vet --concrete").run()?;
+    verbose_cd(&sh, project_root());
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(_cmd) = cmd_option {
+        let args = vec![
+            "fix",
+            "--allow-no-vcs",
+            "--all-features",
+            "--edition-idioms",
+        ];
+        cargo_cmd(config, &sh)?.unwrap().args(args).run()?;
+
+        let args = vec![
+            "clippy",
+            "--all-targets",
+            "--all-features",
+            "--fix",
+            "--allow-no-vcs",
+        ];
+        cargo_cmd(config, &sh)?.unwrap().args(args).run()?;
+
+        let args = vec![
+            "clippy",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ];
+        cargo_cmd(config, &sh)?.unwrap().args(args).run()?;
+    }
+
     Ok(())
 }
 
-fn format_cue() -> Result<()> {
+fn format_rust(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
-    verbose_cd(&sh, cue_dir());
-    cmd!(sh, "cue fmt --simplify").run()?;
-    Ok(())
-}
+    verbose_cd(&sh, project_root());
 
-fn regenerate_ci_yaml() -> Result<()> {
-    let sh = Shell::new()?;
-    verbose_cd(&sh, cue_dir());
-    cmd!(sh, "cue cmd regen-ci-yaml").run()?;
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["fmt"];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 use xshell::{cmd, Shell};
 
 use crate::utils::{project_root, verbose_cd};
+use crate::Config;
 
-pub fn rust_dependencies() -> Result<()> {
+pub fn rust_dependencies(_config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,38 +2,79 @@ use std::env;
 
 use anyhow::Result;
 
+mod commands;
 mod coverage;
 mod fixup;
 mod install;
 mod utils;
 
 const HELP: &str = "\
-NAME
-    cargo xtask - helper scripts for running common project tasks
+cargo xtask - helper scripts for running common project tasks
 
-SYNOPSIS
-    cargo xtask --help
-    cargo xtask [COMMAND...]
+USAGE:
+    cargo xtask [OPTIONS] [TASK]...
 
-COMMANDS
-    coverage               Generate and print a code coverage report summary.
-    coverage.html          Generate and open an HTML code coverage report.
-    fixup                  Run all fixup xtasks, editing files in-place.
-    fixup.github-actions   Format CUE files in-place and regenerate CI YAML files.
-    fixup.markdown         Format Markdown files in-place.
-    fixup.rust             Fix lints and format Rust files in-place.
-    fixup.spelling         Fix common misspellings across all files in-place.
-    install                Install required Rust components and cargo dependencies.
+OPTIONS:
+    -i, --ignore-missing   Ignores any missing tools; only warns
+    -h, --help             Prints help information
+
+TASKS:
+    coverage               Generate and print a code coverage report summary
+    coverage.html          Generate and open an HTML code coverage report
+    fixup                  Run all fixup xtasks, editing files in-place
+    fixup.github-actions   Format CUE files in-place and regenerate CI YAML files
+    fixup.markdown         Format Markdown files in-place
+    fixup.rust             Fix lints and format Rust files in-place
+    fixup.spelling         Fix common misspellings across all files in-place
+    install                Install required Rust components and cargo dependencies
 ";
 
-fn main() -> Result<()> {
-    use lexopt::prelude::*;
+enum Task {
+    Coverage,
+    CoverageHtml,
+    Fixup,
+    FixupGithubActions,
+    FixupMarkdown,
+    FixupRust,
+    FixupSpelling,
+    Install,
+}
 
+pub struct Config {
+    run_tasks: Vec<Task>,
+    ignore_missing_commands: bool,
+}
+
+fn main() -> Result<()> {
     // print help when no arguments are given
     if env::args().len() == 1 {
         print!("{}", HELP);
         std::process::exit(1);
     }
+
+    let config = parse_args()?;
+    for task in &config.run_tasks {
+        match task {
+            Task::Coverage => coverage::report_summary(&config)?,
+            Task::CoverageHtml => coverage::html_report(&config)?,
+            Task::Fixup => fixup::everything(&config)?,
+            Task::FixupGithubActions => fixup::github_actions(&config)?,
+            Task::FixupMarkdown => fixup::markdown(&config)?,
+            Task::FixupRust => fixup::rust(&config)?,
+            Task::FixupSpelling => fixup::spelling(&config)?,
+            Task::Install => install::rust_dependencies(&config)?,
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_args() -> Result<Config> {
+    use lexopt::prelude::*;
+
+    // default config values
+    let mut run_tasks = Vec::new();
+    let mut ignore_missing_commands = false;
 
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
@@ -42,25 +83,36 @@ fn main() -> Result<()> {
                 print!("{}", HELP);
                 std::process::exit(0);
             }
+            Short('i') | Long("ignore-missing") => {
+                ignore_missing_commands = true;
+            }
             Value(value) => {
                 let value = value.string()?;
-                match value.as_str() {
-                    "coverage" => coverage::report_summary()?,
-                    "coverage.html" => coverage::html_report()?,
-                    "fixup" => fixup::everything()?,
-                    "fixup.github-actions" => fixup::github_actions()?,
-                    "fixup.markdown" => fixup::markdown()?,
-                    "fixup.rust" => fixup::rust()?,
-                    "fixup.spelling" => fixup::spelling()?,
-                    "install" => install::rust_dependencies()?,
+                let task = match value.as_str() {
+                    "coverage" => Task::Coverage,
+                    "coverage.html" => Task::CoverageHtml,
+                    "fixup" => Task::Fixup,
+                    "fixup.github-actions" => Task::FixupGithubActions,
+                    "fixup.markdown" => Task::FixupMarkdown,
+                    "fixup.rust" => Task::FixupRust,
+                    "fixup.spelling" => Task::FixupSpelling,
+                    "install" => Task::Install,
                     value => {
-                        anyhow::bail!("unknown command '{}'", value);
+                        anyhow::bail!("unknown task '{}'", value);
                     }
-                }
+                };
+                run_tasks.push(task);
             }
             _ => anyhow::bail!(arg.unexpected()),
         }
     }
 
-    Ok(())
+    if run_tasks.is_empty() {
+        anyhow::bail!("missing task");
+    }
+
+    Ok(Config {
+        run_tasks,
+        ignore_missing_commands,
+    })
 }


### PR DESCRIPTION
This allows a user to skip any tasks that call commands that aren't installed on their system. If a command is missing, special care is taken to display a link to help the user install the missing tool. There is a safety check to never allow skipping when xtasks are run in a CI environment.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
