### PR TITLE
Minor rewording of error to prevent confusion

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,7 +108,7 @@ fn parse_args() -> Result<Config> {
     }
 
     if run_tasks.is_empty() {
-        anyhow::bail!("missing task");
+        anyhow::bail!("no task given");
     }
 
     Ok(Config {


### PR DESCRIPTION
Since the option flag is --ignore-missing and refers to a tool/command, it was slightly confusing to see an error of "missing task".

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
