### PR TITLE
Run actionlint as part of fixup.github-actions xtask

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,12 @@ To maintain consistency and avoid bikeshedding, our project also uses automated
 tools to enforce formatting and style conventions for non-Rust files. Ensure
 that you have the following tools installed:
 
+- [actionlint][] for linting GitHub Actions workflow files
 - [codespell][] for spell checking all files
 - [CUE][] for generating and validating YAML files
 - [Prettier][] for formatting Markdown files
 
+[actionlint]: https://github.com/rhysd/actionlint
 [codespell]: https://github.com/codespell-project/codespell
 [CUE]: https://cuelang.org/
 [Prettier]: https://prettier.io/

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -4,6 +4,15 @@ use xshell::{cmd, Cmd, Shell};
 
 use crate::Config;
 
+pub(crate) fn actionlint_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    create_cmd(
+        "actionlint",
+        "https://github.com/rhysd/actionlint",
+        config,
+        sh,
+    )
+}
+
 pub(crate) fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
     create_cmd(
         "cargo",

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use xshell::Shell;
 
-use crate::commands::{cargo_cmd, codespell_cmd, cue_cmd, prettier_cmd};
+use crate::commands::{actionlint_cmd, cargo_cmd, codespell_cmd, cue_cmd, prettier_cmd};
 use crate::utils::{find_files, project_root, to_relative_paths, verbose_cd};
 use crate::Config;
 
@@ -32,6 +32,7 @@ pub fn github_actions(config: &Config) -> Result<()> {
     lint_cue(config)?;
     format_cue(config)?;
     regenerate_ci_yaml(config)?;
+    lint_workflows(config)?;
     Ok(())
 }
 
@@ -97,6 +98,18 @@ fn regenerate_ci_yaml(config: &Config) -> Result<()> {
 
 fn cue_dir() -> PathBuf {
     project_root().join(".github/cue")
+}
+
+fn lint_workflows(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+
+    let cmd_option = actionlint_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        cmd.run()?;
+    }
+
+    Ok(())
 }
 
 fn lint_rust(config: &Config) -> Result<()> {


### PR DESCRIPTION
This matches our CI job.

See:
- https://github.com/rhysd/actionlint

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
