### PR TITLE
Add an initial dist xtask for packaging release artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "lexopt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,28 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "mini-internal"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261391cc14a85f1f05253c3f7b6f75937280f4171d72b3acf6548bad73b99626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniserde"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f290fd592e7e59944141a818bcdf2823cd5996b1c3001e97f5c28b556305e31"
+dependencies = [
+ "itoa",
+ "mini-internal",
+ "ryu",
+]
 
 [[package]]
 name = "mybin"
@@ -74,6 +102,24 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -104,6 +150,29 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "wasi"
@@ -144,6 +213,7 @@ dependencies = [
  "anyhow",
  "is_ci",
  "lexopt",
+ "miniserde",
  "which",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ license = "MIT OR Apache-2.0"
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.
 debug = 0
+
+[profile.release]
+strip = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,5 +12,6 @@ publish = false
 anyhow = "1.0.71"
 is_ci = "1.1.1"
 lexopt = "0.3.0"
+miniserde = "0.1.30"
 which = "4.4.0"
 xshell = "0.2.2"

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -14,8 +14,9 @@ pub(crate) fn actionlint_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Optio
 }
 
 pub(crate) fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Result<Option<Cmd<'a>>> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     create_cmd(
-        "cargo",
+        cargo.as_str(),
         "https://www.rust-lang.org/learn/get-started",
         config,
         sh,

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,0 +1,109 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use miniserde::{json, Deserialize};
+use xshell::Shell;
+
+use crate::commands::cargo_cmd;
+use crate::utils::{project_root, verbose_cd};
+use crate::Config;
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    packages: Vec<Package>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Package {
+    #[allow(dead_code)]
+    name: String,
+    targets: Vec<Target>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Target {
+    kind: Vec<String>,
+    name: String,
+}
+
+pub fn dist(config: &Config) -> Result<()> {
+    let _ = fs::remove_dir_all(dist_dir());
+    fs::create_dir_all(dist_dir())?;
+
+    dist_binary(config)?;
+    // TODO: dist_manpage()?;
+
+    Ok(())
+}
+
+fn dist_binary(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["build", "--release", "--bins"];
+        cmd.args(args).run()?;
+    }
+
+    let binaries = project_binaries(config)?;
+    for binary in &binaries {
+        if binary == "xtask" {
+            eprintln!("Ignoring xtask binary");
+            continue;
+        }
+
+        let binary_filename = if cfg!(target_os = "windows") {
+            format!("{}.exe", binary)
+        } else {
+            binary.to_string()
+        };
+        let src = release_dir().join(&binary_filename);
+        let dest = dist_dir().join(&binary_filename);
+
+        eprintln!("Copying {} to {}", src.display(), dest.display());
+        fs::copy(&src, &dest)?;
+    }
+
+    Ok(())
+}
+
+fn project_binaries(config: &Config) -> Result<Vec<String>> {
+    let sh = Shell::new()?;
+    let mut binaries = Vec::new();
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["metadata", "--no-deps", "--format-version=1"];
+        let output = cmd.args(args).output()?;
+
+        let metadata_json = String::from_utf8(output.stdout)?;
+        let metadata: Metadata = json::from_str(&metadata_json)?;
+
+        for package in metadata.packages {
+            for target in &package.targets {
+                if target.kind.contains(&"bin".to_string()) {
+                    eprintln!("{:?}", package);
+                    binaries.push(target.name.clone());
+                }
+            }
+        }
+    }
+
+    Ok(binaries)
+}
+
+fn dist_dir() -> PathBuf {
+    target_dir().join("dist")
+}
+
+fn release_dir() -> PathBuf {
+    target_dir().join("release")
+}
+
+fn target_dir() -> PathBuf {
+    let relative_path = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    PathBuf::from(relative_path)
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 mod commands;
 mod coverage;
+mod dist;
 mod fixup;
 mod install;
 mod utils;
@@ -21,6 +22,7 @@ OPTIONS:
 TASKS:
     coverage               Generate and print a code coverage report summary
     coverage.html          Generate and open an HTML code coverage report
+    dist                   Package project assets into distributable artifacts
     fixup                  Run all fixup xtasks, editing files in-place
     fixup.github-actions   Format CUE files in-place and regenerate CI YAML files
     fixup.markdown         Format Markdown files in-place
@@ -32,6 +34,7 @@ TASKS:
 enum Task {
     Coverage,
     CoverageHtml,
+    Dist,
     Fixup,
     FixupGithubActions,
     FixupMarkdown,
@@ -57,6 +60,7 @@ fn main() -> Result<()> {
         match task {
             Task::Coverage => coverage::report_summary(&config)?,
             Task::CoverageHtml => coverage::html_report(&config)?,
+            Task::Dist => dist::dist(&config)?,
             Task::Fixup => fixup::everything(&config)?,
             Task::FixupGithubActions => fixup::github_actions(&config)?,
             Task::FixupMarkdown => fixup::markdown(&config)?,
@@ -91,6 +95,7 @@ fn parse_args() -> Result<Config> {
                 let task = match value.as_str() {
                     "coverage" => Task::Coverage,
                     "coverage.html" => Task::CoverageHtml,
+                    "dist" => Task::Dist,
                     "fixup" => Task::Fixup,
                     "fixup.github-actions" => Task::FixupGithubActions,
                     "fixup.markdown" => Task::FixupMarkdown,


### PR DESCRIPTION
There's more work to be done here, but it's a start. Honestly, adding miniserde just to parse out the Cargo metadata seems way more difficult than it should be to get an accurate list of the binary artifacts for the project. There is an unstable `--out-dir` feature to copy artifacts for you after building, but it hasn't stabilized over the past couple of years. Not ideal.

```
$ cargo xtask dist
    Finished dev [unoptimized] target(s) in 0.01s
     Running `target/debug/xtask dist`

$ cd /Users/elasticdog/src/rustops-blueprint/
$ /Users/elasticdog/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo build --release --bins
    Finished release [optimized] target(s) in 0.02s
Package { name: "mybin", targets: [Target { kind: ["bin"], name: "mybin" }] }
Package { name: "xtask", targets: [Target { kind: ["bin"], name: "xtask" }] }
Copying target/release/mybin to target/dist/mybin
Ignoring xtask binary
```

See:
- https://github.com/rust-lang/cargo/issues/3757
- https://github.com/rust-lang/cargo/issues/6790#issuecomment-1488959163
- https://github.com/matklad/cargo-xtask/issues/3

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
