### PR TITLE
Always use the cargo_cmd function instead of cmd! directly

### DIFF
--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,23 +1,38 @@
 use anyhow::Result;
-use xshell::{cmd, Shell};
+use xshell::Shell;
 
+use crate::commands::cargo_cmd;
 use crate::utils::{project_root, verbose_cd};
 use crate::Config;
 
-pub fn html_report(_config: &Config) -> Result<()> {
+pub fn html_report(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
-    cmd!(
-        sh,
-        "cargo llvm-cov nextest --ignore-filename-regex xtask --open"
-    )
-    .run()?;
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec![
+            "llvm-cov",
+            "nextest",
+            "--ignore-filename-regex",
+            "xtask",
+            "--open",
+        ];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }
 
-pub fn report_summary(_config: &Config) -> Result<()> {
+pub fn report_summary(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
-    cmd!(sh, "cargo llvm-cov nextest --ignore-filename-regex xtask").run()?;
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["llvm-cov", "nextest", "--ignore-filename-regex", "xtask"];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -1,14 +1,21 @@
 use anyhow::Result;
 use xshell::{cmd, Shell};
 
+use crate::commands::cargo_cmd;
 use crate::utils::{project_root, verbose_cd};
 use crate::Config;
 
-pub fn rust_dependencies(_config: &Config) -> Result<()> {
+pub fn rust_dependencies(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 
     cmd!(sh, "rustup component add clippy rustfmt").run()?;
-    cmd!(sh, "cargo install cargo-insta cargo-llvm-cov cargo-nextest").run()?;
+
+    let cmd_option = cargo_cmd(config, &sh)?;
+    if let Some(cmd) = cmd_option {
+        let args = vec!["install", "cargo-insta", "cargo-llvm-cov", "cargo-nextest"];
+        cmd.args(args).run()?;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
The function handles the $CARGO environment variable properly, although I'm honestly not sure when people would actually override the default auto-detected path.

See:
- https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
