### PR TITLE
Switch from miniserde to nanoserde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
 name = "lexopt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,28 +48,6 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "mini-internal"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261391cc14a85f1f05253c3f7b6f75937280f4171d72b3acf6548bad73b99626"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "miniserde"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f290fd592e7e59944141a818bcdf2823cd5996b1c3001e97f5c28b556305e31"
-dependencies = [
- "itoa",
- "mini-internal",
- "ryu",
-]
 
 [[package]]
 name = "mybin"
@@ -92,6 +64,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoserde"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755e7965536bc54d7c9fba2df5ada5bf835b0443fd613f0a53fa199a301839d3"
+dependencies = [
+ "nanoserde-derive",
+]
+
+[[package]]
+name = "nanoserde-derive"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7a94da6c6181c35d043fc61c43ac96d3a5d739e7b8027f77650ba41504d6ab"
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,24 +89,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "rand"
@@ -150,29 +119,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "syn"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "wasi"
@@ -213,7 +159,7 @@ dependencies = [
  "anyhow",
  "is_ci",
  "lexopt",
- "miniserde",
+ "nanoserde",
  "which",
  "xshell",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 anyhow = "1.0.71"
 is_ci = "1.1.1"
 lexopt = "0.3.0"
-miniserde = "0.1.30"
+nanoserde = "0.1.32"
 which = "4.4.0"
 xshell = "0.2.2"

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -3,26 +3,26 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use miniserde::{json, Deserialize};
+use nanoserde::DeJson;
 use xshell::Shell;
 
 use crate::commands::cargo_cmd;
 use crate::utils::{project_root, verbose_cd};
 use crate::Config;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, DeJson)]
 struct Metadata {
     packages: Vec<Package>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, DeJson)]
 struct Package {
     #[allow(dead_code)]
     name: String,
     targets: Vec<Target>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, DeJson)]
 struct Target {
     kind: Vec<String>,
     name: String,
@@ -80,7 +80,7 @@ fn project_binaries(config: &Config) -> Result<Vec<String>> {
         let output = cmd.args(args).output()?;
 
         let metadata_json = String::from_utf8(output.stdout)?;
-        let metadata: Metadata = json::from_str(&metadata_json)?;
+        let metadata: Metadata = DeJson::deserialize_json(&metadata_json)?;
 
         for package in metadata.packages {
             for target in &package.targets {


### PR DESCRIPTION
This works just fine for the purposes of parsing `cargo metadata`, is a bit smaller and has no external dependencies. Compilation time improves as well for the xtask package, although the resulting binary is a bit bigger.

# miniserde

```
$ cargo tree -p xtask
xtask v0.1.0 (/Users/elasticdog/src/rustops-blueprint/xtask)
├── anyhow v1.0.71
├── is_ci v1.1.1
├── lexopt v0.3.0
├── miniserde v0.1.30
│   ├── itoa v1.0.6
│   ├── mini-internal v0.1.30 (proc-macro)
│   │   ├── proc-macro2 v1.0.58
│   │   │   └── unicode-ident v1.0.8
│   │   ├── quote v1.0.27
│   │   │   └── proc-macro2 v1.0.58 (*)
│   │   └── syn v2.0.16
│   │       ├── proc-macro2 v1.0.58 (*)
│   │       ├── quote v1.0.27 (*)
│   │       └── unicode-ident v1.0.8
│   └── ryu v1.0.13
├── which v4.4.0
│   ├── either v1.8.1
│   └── libc v0.2.144
└── xshell v0.2.3
    └── xshell-macros v0.2.3 (proc-macro)

$ hyperfine --prepare 'cargo clean' 'cargo build --release -p xtask'
Benchmark 1: cargo build --release -p xtask
  Time (mean ± σ):      2.836 s ±  0.051 s    [User: 8.506 s, System: 1.596 s]
  Range (min … max):    2.768 s …  2.959 s    10 runs

$ ls -lh target/release/xtask
-rwxr-xr-x@ 1 elasticdog  staff   515K May 20 08:54 target/release/xtask
```

# nanoserde

```
$ cargo tree -p xtask
xtask v0.1.0 (/Users/elasticdog/src/rustops-blueprint/xtask)
├── anyhow v1.0.71
├── is_ci v1.1.1
├── lexopt v0.3.0
├── nanoserde v0.1.32
│   └── nanoserde-derive v0.1.19 (proc-macro)
├── which v4.4.0
│   ├── either v1.8.1
│   └── libc v0.2.144
└── xshell v0.2.3
    └── xshell-macros v0.2.3 (proc-macro)

$ hyperfine --prepare 'cargo clean' 'cargo build --release -p xtask'
Benchmark 1: cargo build --release -p xtask
  Time (mean ± σ):      1.705 s ±  0.114 s    [User: 6.534 s, System: 0.883 s]
  Range (min … max):    1.614 s …  1.922 s    10 runs

$ ls -lh target/release/xtask
-rwxr-xr-x@ 1 elasticdog  staff   565K May 20 16:52 target/release/xtask
```

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
