### PR TITLE
Add a rust-toolchain.toml file

### DIFF
--- a/.github/cue/github-pages.cue
+++ b/.github/cue/github-pages.cue
@@ -36,7 +36,7 @@ githubPages: {
 				{
 					name: "Build docs"
 					env: RUSTDOCFLAGS: "--enable-index-page -Z unstable-options"
-					run: "cargo doc --no-deps"
+					run: "cargo +nightly doc --no-deps"
 				},
 				_#uploadPagesArtifact & {with: path: "target/doc"},
 			]

--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -31,6 +31,10 @@ scheduled: {
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: toolchain: "beta"},
+				{
+					name: "Set override to beta Rust"
+					run:  "rustup override set beta"
+				},
 				for step in _testRust {step},
 			]
 		}

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -114,8 +114,8 @@ _setupMsrv: [
 		run:  "cargo +nightly update -Z direct-minimal-versions"
 	},
 	{
-		name: "Default to MSRV Rust"
-		run:  "rustup default ${{ steps.msrv.outputs.version }}"
+		name: "Set override to MSRV Rust"
+		run:  "rustup override set ${{ steps.msrv.outputs.version }}"
 	},
 ]
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build docs
         env:
           RUSTDOCFLAGS: --enable-index-page -Z unstable-options
-        run: cargo doc --no-deps
+        run: cargo +nightly doc --no-deps
       - name: Upload github-pages artifact
         uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187
         with:

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -98,8 +98,8 @@ jobs:
           toolchain: nightly
       - name: Resolve minimal dependency versions instead of maximum
         run: cargo +nightly update -Z direct-minimal-versions
-      - name: Default to MSRV Rust
-        run: rustup default ${{ steps.msrv.outputs.version }}
+      - name: Set override to MSRV Rust
+        run: rustup override set ${{ steps.msrv.outputs.version }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -177,8 +177,8 @@ jobs:
           toolchain: nightly
       - name: Resolve minimal dependency versions instead of maximum
         run: cargo +nightly update -Z direct-minimal-versions
-      - name: Default to MSRV Rust
-        run: rustup default ${{ steps.msrv.outputs.version }}
+      - name: Set override to MSRV Rust
+        run: rustup override set ${{ steps.msrv.outputs.version }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01
         with:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,6 +24,8 @@ jobs:
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: beta
+      - name: Set override to beta Rust
+        run: rustup override set beta
       - name: Install cargo-nextest
         uses: taiki-e/install-action@97bdefc2d9c284a0a0e620f6d484dd156d256e81
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is low-hanging fruit and can help ensure that the required toolchain components are installed without user intervention (for instance if they're running a minimal profile). It also helps self- document the use of the stable Rust release channel.

See:
- https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
