### PR TITLE
Remove check job from main Rust workflow

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -13,19 +13,6 @@ rust: _#useMergeQueue & {
 	jobs: {
 		changes: _#detectFileChanges
 
-		check: {
-			name: "check"
-			needs: ["changes"]
-			"runs-on": defaultRunner
-			if:        "needs.changes.outputs.rust == 'true'"
-			steps: [
-				_#checkoutCode,
-				_#installRust,
-				_#cacheRust,
-				_#cargoCheck,
-			]
-		}
-
 		format: {
 			name: "format"
 			needs: ["changes"]
@@ -53,14 +40,14 @@ rust: _#useMergeQueue & {
 				_#cacheRust,
 				{
 					name: "Check lints"
-					run:  "cargo clippy --all-targets --all-features -- -D warnings"
+					run:  "cargo clippy --locked --all-targets --all-features -- -D warnings"
 				},
 			]
 		}
 
 		test_stable: {
 			name: "test / stable"
-			needs: ["changes", "check", "format", "lint"]
+			needs: ["changes", "format", "lint"]
 			defaults: run: shell: "bash"
 			strategy: {
 				"fail-fast": false
@@ -83,7 +70,7 @@ rust: _#useMergeQueue & {
 		// Minimum Supported Rust Version
 		test_msrv: {
 			name: "test / msrv"
-			needs: ["changes", "check", "format", "lint"]
+			needs: ["changes", "format", "lint"]
 			"runs-on": defaultRunner
 			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,26 +49,6 @@ jobs:
               - '**/*.rs'
               - '**/Cargo.*'
               - .github/workflows/rust.yml
-  check:
-    name: check
-    needs:
-      - changes
-    runs-on: ubuntu-latest
-    if: needs.changes.outputs.rust == 'true'
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
-        with:
-          toolchain: stable
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01
-        with:
-          shared-key: stable-ubuntu-latest
-        timeout-minutes: 5
-      - name: Check packages and dependencies for errors
-        run: cargo check --locked --all-targets --all-features
   format:
     name: format
     needs:
@@ -110,12 +90,11 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Check lints
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
   test_stable:
     name: test / stable
     needs:
       - changes
-      - check
       - format
       - lint
     defaults:
@@ -156,7 +135,6 @@ jobs:
     name: test / msrv
     needs:
       - changes
-      - check
       - format
       - lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
A dedicated `cargo check` is superfluous since `cargo clippy` already checks the files before it runs it's own linting. This saves a bit of compute time.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
