### PR TITLE
Add explicit clippy lint categories per crate

### DIFF
--- a/crates/mylib/src/lib.rs
+++ b/crates/mylib/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use rand::seq::SliceRandom;
 
 #[must_use]

--- a/crates/mylib/src/lib.rs
+++ b/crates/mylib/src/lib.rs
@@ -1,7 +1,7 @@
 use rand::seq::SliceRandom;
 
 #[must_use]
-pub fn add(left: usize, right: usize) -> usize {
+pub const fn add(left: usize, right: usize) -> usize {
     left + right
 }
 

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -121,6 +121,7 @@ fn lint_rust(config: &Config) -> Result<()> {
         let args = vec![
             "fix",
             "--allow-no-vcs",
+            "--all-targets",
             "--all-features",
             "--edition-idioms",
         ];
@@ -128,10 +129,10 @@ fn lint_rust(config: &Config) -> Result<()> {
 
         let args = vec![
             "clippy",
-            "--all-targets",
-            "--all-features",
             "--fix",
             "--allow-no-vcs",
+            "--all-targets",
+            "--all-features",
         ];
         cargo_cmd(config, &sh).unwrap().args(args).run()?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use std::env;
 
 use anyhow::Result;


### PR DESCRIPTION
When developing, we'll deny all the default lints, and warn about nursery and pedandic lints, but CI will deny those as well.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
