### PR TITLE
Ensure workflows fail appropriately

### DIFF
--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -82,8 +82,8 @@ githubActions: _#useMergeQueue & {
 			]
 		}
 
-		lint: {
-			name: "lint"
+		workflows_lint: {
+			name: "workflows / lint"
 			needs: ["cue_synced"]
 			"runs-on": defaultRunner
 			steps: [
@@ -94,8 +94,10 @@ githubActions: _#useMergeQueue & {
 
 		merge_queue: needs: [
 			"changes",
+			"cue_vet",
 			"cue_format",
-			"lint",
+			"cue_synced",
+			"workflows_lint",
 		]
 	}
 }

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -17,7 +17,7 @@ rust: _#useMergeQueue & {
 			name: "format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'"
+			if:        "needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "rustfmt"},
@@ -33,7 +33,7 @@ rust: _#useMergeQueue & {
 			name: "lint"
 			needs: ["changes"]
 			"runs-on": defaultRunner
-			if:        "github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'"
+			if:        "needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "clippy"},
@@ -47,7 +47,7 @@ rust: _#useMergeQueue & {
 
 		test_stable: {
 			name: "test / stable"
-			needs: ["changes", "format", "lint"]
+			needs: ["format", "lint"]
 			defaults: run: shell: "bash"
 			strategy: {
 				"fail-fast": false
@@ -58,7 +58,6 @@ rust: _#useMergeQueue & {
 				]
 			}
 			"runs-on": "${{ matrix.platform }}"
-			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -70,9 +69,8 @@ rust: _#useMergeQueue & {
 		// Minimum Supported Rust Version
 		test_msrv: {
 			name: "test / msrv"
-			needs: ["changes", "format", "lint"]
+			needs: ["format", "lint"]
 			"runs-on": defaultRunner
-			if:        "always() && needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
 				for step in _setupMsrv {step},
@@ -83,6 +81,8 @@ rust: _#useMergeQueue & {
 
 		merge_queue: needs: [
 			"changes",
+			"format",
+			"lint",
 			"test_stable",
 			"test_msrv",
 		]

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -114,8 +114,8 @@ jobs:
               echo "Run 'cargo xtask fixup.github-actions' locally to regenerate the YAML from CUE."
               exit 1
           fi
-  lint:
-    name: lint
+  workflows_lint:
+    name: workflows / lint
     needs:
       - cue_synced
     runs-on: ubuntu-latest
@@ -128,14 +128,26 @@ jobs:
     name: github-actions workflow ready
     needs:
       - changes
+      - cue_vet
       - cue_format
-      - lint
+      - cue_synced
+      - workflows_lint
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: 'Check status of job_id: changes'
         run: |-
           RESULT="${{ needs.changes.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
+      - name: 'Check status of job_id: cue_vet'
+        run: |-
+          RESULT="${{ needs.cue_vet.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else
@@ -153,9 +165,19 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: lint'
+      - name: 'Check status of job_id: cue_synced'
         run: |-
-          RESULT="${{ needs.lint.result }}";
+          RESULT="${{ needs.cue_synced.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
+      - name: 'Check status of job_id: workflows_lint'
+        run: |-
+          RESULT="${{ needs.workflows_lint.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -75,7 +75,7 @@ jobs:
     needs:
       - changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -94,7 +94,6 @@ jobs:
   test_stable:
     name: test / stable
     needs:
-      - changes
       - format
       - lint
     defaults:
@@ -108,7 +107,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.platform }}
-    if: always() && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -134,11 +132,9 @@ jobs:
   test_msrv:
     name: test / msrv
     needs:
-      - changes
       - format
       - lint
     runs-on: ubuntu-latest
-    if: always() && needs.changes.outputs.rust == 'true'
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -176,6 +172,8 @@ jobs:
     name: rust workflow ready
     needs:
       - changes
+      - format
+      - lint
       - test_stable
       - test_msrv
     runs-on: ubuntu-latest
@@ -184,6 +182,26 @@ jobs:
       - name: 'Check status of job_id: changes'
         run: |-
           RESULT="${{ needs.changes.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
+      - name: 'Check status of job_id: format'
+        run: |-
+          RESULT="${{ needs.format.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
+      - name: 'Check status of job_id: lint'
+        run: |-
+          RESULT="${{ needs.lint.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/crates/mylib/tests/integration/main.rs
+++ b/crates/mylib/tests/integration/main.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use mylib::shuffle_array;
 
 #[test]


### PR DESCRIPTION
I noticed when adding all of the clippy code, that the lint job failed, and the stable and msrv tests still ran (because of the `always()` conditional), and then the workflow passed. This logic is all a bit convoluted, but necessary to save on timing and compute resources.

![Screenshot 2023-05-21 at 6 58 13 AM](https://github.com/EarthmanMuons/rustops-blueprint/assets/4742/8c1efbe3-e278-4489-b6cd-c08fabcc3cb9)

Related to https://github.com/EarthmanMuons/rustops-blueprint/pull/99

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
