### PR TITLE
Rely on deny warnings to catch all configured clippy lints

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -40,7 +40,7 @@ rust: _#useMergeQueue & {
 				_#cacheRust,
 				{
 					name: "Check lints"
-					run:  "cargo clippy --locked --all-targets --all-features -- -W clippy::pedantic -D warnings"
+					run:  "cargo clippy --locked --all-targets --all-features -- -D warnings"
 				},
 			]
 		}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Check lints
-        run: cargo clippy --locked --all-targets --all-features -- -W clippy::pedantic -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
   test_stable:
     name: test / stable
     needs:


### PR DESCRIPTION
Now that we put the various lint categories into the files themselves, we can just rely on CI to deny all warnings rather than explicitly adding the pedantic category. This should make it more maintainable since if we need exceptions, we can just put them in the source files directly and not cause issues.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
