### PR TITLE
Fix import-jsonschema CUE command's output path

### DIFF
--- a/.github/cue/ci_tool.cue
+++ b/.github/cue/ci_tool.cue
@@ -18,7 +18,7 @@ command: "import-jsonschema": {
 		url: "https://raw.githubusercontent.com/SchemaStore/schemastore/\(_commit)/src/schemas/json/github-workflow.json"
 	}
 	import: exec.Run & {
-		_outpath: path.FromSlash("../cue.mod/pkg/json.schemastore.org/github/github-workflow.cue", path.Unix)
+		_outpath: path.FromSlash("cue.mod/pkg/json.schemastore.org/github/github-workflow.cue", path.Unix)
 		stdin:    getJSONSchema.response.body
 		cmd:      "cue import -f -p github -l #Workflow: -o \(_outpath) jsonschema: -"
 	}


### PR DESCRIPTION
When I shuffled around the directories, I never updated this relative path.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
