### PR TITLE
Use new group-result feature of actionlint action

### DIFF
--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -18,7 +18,8 @@ _#step: uses?: #pinned
 // https://github.com/raven-actions/actionlint/releases
 _#actionlint: _#step & {
 	name: "Check lints"
-	uses: "raven-actions/actionlint@a143169aa718a5c056297c13a123fa1fb0cb6040"
+	uses: "raven-actions/actionlint@d6c9e3222b489401880e866bc6715049773b63a3"
+	with: "group-result": false
 }
 
 // https://github.com/Swatinem/rust-cache/releases

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -123,7 +123,9 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Check lints
-        uses: raven-actions/actionlint@a143169aa718a5c056297c13a123fa1fb0cb6040
+        uses: raven-actions/actionlint@d6c9e3222b489401880e866bc6715049773b63a3
+        with:
+          group-result: false
   merge_queue:
     name: github-actions workflow ready
     needs:


### PR DESCRIPTION
This was a feature request I had made upstream to automatically have any failure results expanded when viewing the actionlint output.

Related to https://github.com/raven-actions/actionlint/issues/8

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
