### PR TITLE
Preload cache on main branch with actionlint binary

### DIFF
--- a/.github/cue/preload-caches.cue
+++ b/.github/cue/preload-caches.cue
@@ -61,8 +61,19 @@ preloadCaches: {
 			]
 		}
 
-		cache_stable: {
-			name: "cache / stable"
+		actionlint: {
+			name: "actionlint"
+			needs: ["flush_caches"]
+			if:        "always()"
+			"runs-on": defaultRunner
+			steps: [
+				_#checkoutCode,
+				_#actionlint & {with: flags: "-version"},
+			]
+		}
+
+		rust_stable: {
+			name: "rust / stable"
 			needs: ["flush_caches"]
 			if: "always()"
 			defaults: run: shell: "bash"
@@ -85,8 +96,8 @@ preloadCaches: {
 		}
 
 		// Minimum Supported Rust Version
-		cache_msrv: {
-			name: "cache / msrv"
+		rust_msrv: {
+			name: "rust / msrv"
 			needs: ["flush_caches"]
 			if:        "always()"
 			"runs-on": defaultRunner

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -42,8 +42,22 @@ jobs:
           for key in $cacheKeys; do
               gh actions-cache delete "$key" -R $REPO -B $BRANCH --confirm
           done
-  cache_stable:
-    name: cache / stable
+  actionlint:
+    name: actionlint
+    needs:
+      - flush_caches
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Check lints
+        uses: raven-actions/actionlint@d6c9e3222b489401880e866bc6715049773b63a3
+        with:
+          group-result: false
+          flags: -version
+  rust_stable:
+    name: rust / stable
     needs:
       - flush_caches
     if: always()
@@ -76,8 +90,8 @@ jobs:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
         run: cargo check --locked --all-targets --all-features
-  cache_msrv:
-    name: cache / msrv
+  rust_msrv:
+    name: rust / msrv
     needs:
       - flush_caches
     if: always()


### PR DESCRIPTION
Otherwise, this will keep being cached by every PR and merge queue run that triggers the github-actions workflow.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
