### PR TITLE
Set override on Miri job to use nightly

### DIFF
--- a/.github/cue/scheduled.cue
+++ b/.github/cue/scheduled.cue
@@ -51,6 +51,10 @@ scheduled: {
 					components: "miri"
 				}},
 				{
+					name: "Set override to nightly Rust"
+					run:  "rustup override set nightly"
+				},
+				{
 					name: "Setup Miri environment"
 					run:  "cargo miri setup"
 				},

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           toolchain: nightly
           components: miri
+      - name: Set override to nightly Rust
+        run: rustup override set nightly
       - name: Setup Miri environment
         run: cargo miri setup
       - name: Compile tests with Miri


### PR DESCRIPTION
With the addition of the `rust-toolchain.toml` file, it was defaulting to stable where the Miri component is not available.

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
