### PR TITLE
Document manual installation process for cargo-watch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ the installation process, follow these steps:
 2. Install the required cargo dependencies:
 
    ```
-   cargo install cargo-insta cargo-llvm-cov cargo-nextest
+   cargo install cargo-insta cargo-llvm-cov cargo-nextest cargo-watch
    ```
 
 ### Install Additional Tools


### PR DESCRIPTION
I missed this when mentioning it as a recommended dependency.

Related to https://github.com/EarthmanMuons/rustops-blueprint/pull/135

# Checklist

- [x] Ran `cargo xtask fixup` for project formatting and style
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering my changes
