### PR TITLE
Use nightly rustfmt with unstable config options

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -20,11 +20,13 @@ rust: _#useMergeQueue & {
 			if:        "needs.changes.outputs.rust == 'true'"
 			steps: [
 				_#checkoutCode,
-				_#installRust & {with: components: "rustfmt"},
-				_#cacheRust,
+				_#installRust & {with: {
+					toolchain:  "nightly"
+					components: "rustfmt"
+				}},
 				{
 					name: "Check formatting"
-					run:  "cargo fmt --check"
+					run:  "cargo +nightly fmt --check"
 				},
 			]
 		}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,18 +58,13 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Install stable Rust toolchain
+      - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@988c164c3d0e93c4dbab36aaf5bbeb77425b2894
-        with:
-          shared-key: stable-ubuntu-latest
-        timeout-minutes: 5
       - name: Check formatting
-        run: cargo fmt --check
+        run: cargo +nightly fmt --check
   lint:
     name: lint
     needs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ git remote add upstream https://github.com/EarthmanMuons/rustops-blueprint.git
 The project is developed using the latest stable release of Rust, but it also
 requires a couple of additional toolchain [components][]. We use the lint tool
 [`clippy`][] for extra checks on common mistakes and stylistic choices, as well
-as [`rustfmt`][] for automatic code formatting.
+as the _nightly_ version of [`rustfmt`][] for automatic code formatting.
 
 Additionally, our project utilizes [`cargo-insta`][] for snapshot testing,
 [`cargo-llvm-cov`][] to generate code coverage reports, and [`cargo-nextest`][]
@@ -113,10 +113,11 @@ cargo xtask install
 If you prefer to install the required tools manually, or need more control over
 the installation process, follow these steps:
 
-1. Install the required toolchain components:
+1. Install the required toolchains and components:
 
    ```
-   rustup component add clippy rustfmt
+   rustup toolchain add stable --component clippy
+   rustup toolchain add nightly --component rustfmt
    ```
 
 2. Install the required cargo dependencies:
@@ -270,7 +271,7 @@ Most other commands are the same as any standard Rust project:
 - Format the code
 
   ```
-  cargo fmt
+  cargo +nightly fmt
   ```
 
 - Run tests and doctests

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+error_on_line_overflow = true
+format_strings = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+max_width = 100
+wrap_comments = true

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -14,9 +14,8 @@ pub fn actionlint_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
 }
 
 pub fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     create_cmd(
-        cargo.as_str(),
+        "cargo",
         "https://www.rust-lang.org/learn/get-started",
         config,
         sh,

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -27,7 +27,8 @@ pub fn install_rust_deps(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 
-    cmd!(sh, "rustup component add clippy rustfmt").run()?;
+    cmd!(sh, "rustup toolchain add stable --component clippy").run()?;
+    cmd!(sh, "rustup toolchain add nightly --component rustfmt").run()?;
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,9 +1,8 @@
 #![deny(clippy::all)]
 #![warn(clippy::nursery, clippy::pedantic)]
 
-use std::env;
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 
 use anyhow::Result;
 use nanoserde::DeJson;

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -156,7 +156,7 @@ fn format_rust(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["fmt"];
+        let args = vec!["+nightly", "fmt"];
         cmd.args(args).run()?;
     }
 


### PR DESCRIPTION
These are really nice config settings, and although they're mostly not stable, we can adjust our process to use nightly for running `cargo fmt`.

Note that I'm getting rid of the code to honor the $CARGO environment variable. It's not a common practice to override it, and in our case, it made switching between toolchains with the override shorthand syntax awkward because running `cargo xtask ...` would set the environment variable to point to the stable toolchain's absolute path. Trying to add `+nightly` to that doesn't work, as there's normally a wrapper shim that decides the version to execute beforehand. It also made the output more confusing to see the whole path in there, and doubly so trying to override things using the $RUSTUP_TOOLCHAIN environment variable instead of the shorthand syntax.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
