### PR TITLE
Remove --all-features from xtask and CI Cargo commands

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -42,7 +42,7 @@ rust: _#useMergeQueue & {
 				_#cacheRust,
 				{
 					name: "Check lints"
-					run:  "cargo clippy --locked --all-targets --all-features -- -D warnings"
+					run:  "cargo clippy --locked --all-targets -- -D warnings"
 				},
 			]
 		}

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -34,7 +34,7 @@ _#cacheRust: _#step & {
 
 _#cargoCheck: _#step & {
 	name: "Check packages and dependencies for errors"
-	run:  "cargo check --locked --all-targets --all-features"
+	run:  "cargo check --locked --all-targets"
 }
 
 // https://github.com/actions/checkout/releases
@@ -128,7 +128,7 @@ _testRust: [
 	},
 	_#step & {
 		name: "Run tests"
-		run:  "cargo nextest run --locked --all-targets --all-features"
+		run:  "cargo nextest run --locked --all-targets"
 	},
 	_#step & {
 		name: "Run doctests"

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
-        run: cargo check --locked --all-targets --all-features
+        run: cargo check --locked --all-targets
   rust_msrv:
     name: rust / msrv
     needs:
@@ -124,4 +124,4 @@ jobs:
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
-        run: cargo check --locked --all-targets --all-features
+        run: cargo check --locked --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
           shared-key: stable-ubuntu-latest
         timeout-minutes: 5
       - name: Check lints
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
   test_stable:
     name: test / stable
     needs:
@@ -121,7 +121,7 @@ jobs:
       - name: Compile tests
         run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo nextest run --locked --all-targets --all-features
+        run: cargo nextest run --locked --all-targets
       - name: Run doctests
         run: cargo test --locked --doc
   test_msrv:
@@ -160,7 +160,7 @@ jobs:
       - name: Compile tests
         run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo nextest run --locked --all-targets --all-features
+        run: cargo nextest run --locked --all-targets
       - name: Run doctests
         run: cargo test --locked --doc
   merge_queue:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Compile tests
         run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo nextest run --locked --all-targets --all-features
+        run: cargo nextest run --locked --all-targets
       - name: Run doctests
         run: cargo test --locked --doc
   miri:

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -11,12 +11,7 @@ pub fn cargo_watch(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec![
-            "watch",
-            "--why",
-            "-x",
-            "clippy --locked --all-targets --all-features",
-        ];
+        let args = vec!["watch", "--why", "-x", "clippy --locked --all-targets"];
         cmd.args(args).run()?;
     }
 
@@ -51,14 +46,7 @@ pub fn test_with_snapshots(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec![
-            "insta",
-            "test",
-            "--all-features",
-            "--test-runner",
-            "nextest",
-            "--review",
-        ];
+        let args = vec!["insta", "test", "--test-runner", "nextest", "--review"];
         cmd.args(args).run()?;
     }
 

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -118,32 +118,13 @@ fn lint_rust(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(_cmd) = cmd_option {
-        let args = vec![
-            "fix",
-            "--allow-no-vcs",
-            "--all-targets",
-            "--all-features",
-            "--edition-idioms",
-        ];
+        let args = vec!["fix", "--allow-no-vcs", "--all-targets", "--edition-idioms"];
         cargo_cmd(config, &sh).unwrap().args(args).run()?;
 
-        let args = vec![
-            "clippy",
-            "--fix",
-            "--allow-no-vcs",
-            "--all-targets",
-            "--all-features",
-        ];
+        let args = vec!["clippy", "--fix", "--allow-no-vcs", "--all-targets"];
         cargo_cmd(config, &sh).unwrap().args(args).run()?;
 
-        let args = vec![
-            "clippy",
-            "--all-targets",
-            "--all-features",
-            "--",
-            "-D",
-            "warnings",
-        ];
+        let args = vec!["clippy", "--all-targets", "--", "-D", "warnings"];
         cargo_cmd(config, &sh).unwrap().args(args).run()?;
     }
 


### PR DESCRIPTION
I'm not currently using any Cargo features, but more importantly, it should be an explicit decision to design around which features are the default, as well as properly testing a powerset of the features you have via something like cargo-hack instead of blindly always testing all of them together. In other words, only checking "all features" or "default features" or "no default features" will potentially miss combinations.

See:
- https://github.com/taiki-e/cargo-hack

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
