### PR TITLE
Rename dev xtask to check

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -5,19 +5,6 @@ use crate::commands::cargo_cmd;
 use crate::utils::{project_root, verbose_cd};
 use crate::Config;
 
-pub fn cargo_watch(config: &Config) -> Result<()> {
-    let sh = Shell::new()?;
-    verbose_cd(&sh, project_root());
-
-    let cmd_option = cargo_cmd(config, &sh);
-    if let Some(cmd) = cmd_option {
-        let args = vec!["watch", "--why", "-x", "clippy --locked --all-targets"];
-        cmd.args(args).run()?;
-    }
-
-    Ok(())
-}
-
 pub fn install_rust_deps(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
@@ -47,6 +34,21 @@ pub fn test_with_snapshots(config: &Config) -> Result<()> {
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
         let args = vec!["insta", "test", "--test-runner", "nextest", "--review"];
+        cmd.args(args).run()?;
+    }
+
+    Ok(())
+}
+
+pub fn watch_clippy(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+
+    println!("\nPress Ctrl-C to stop the program.");
+
+    let cmd_option = cargo_cmd(config, &sh);
+    if let Some(cmd) = cmd_option {
+        let args = vec!["watch", "--why", "-x", "clippy --locked --all-targets"];
         cmd.args(args).run()?;
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,9 +23,9 @@ OPTIONS:
     -h, --help             Prints help information
 
 TASKS:
+    check                  Watch for file changes and auto-trigger clippy linting
     coverage               Generate and print a code coverage report summary
     coverage.html          Generate and open an HTML code coverage report
-    dev                    Watch for file changes and auto-trigger clippy linting
     dist                   Package project assets into distributable artifacts
     fixup                  Run all fixup xtasks, editing files in-place
     fixup.github-actions   Format CUE files in-place and regenerate CI YAML files
@@ -37,9 +37,9 @@ TASKS:
 ";
 
 enum Task {
+    Check,
     Coverage,
     CoverageHtml,
-    Dev,
     Dist,
     Fixup,
     FixupGithubActions,
@@ -65,9 +65,9 @@ fn main() -> Result<()> {
     let config = parse_args()?;
     for task in &config.run_tasks {
         match task {
+            Task::Check => dev::watch_clippy(&config)?,
             Task::Coverage => coverage::report_summary(&config)?,
             Task::CoverageHtml => coverage::html_report(&config)?,
-            Task::Dev => dev::cargo_watch(&config)?,
             Task::Dist => dist::dist(&config)?,
             Task::Fixup => fixup::everything(&config)?,
             Task::FixupGithubActions => fixup::github_actions(&config)?,
@@ -102,9 +102,9 @@ fn parse_args() -> Result<Config> {
             Value(value) => {
                 let value = value.string()?;
                 let task = match value.as_str() {
+                    "check" => Task::Check,
                     "coverage" => Task::Coverage,
                     "coverage.html" => Task::CoverageHtml,
-                    "dev" => Task::Dev,
                     "dist" => Task::Dist,
                     "fixup" => Task::Fixup,
                     "fixup.github-actions" => Task::FixupGithubActions,


### PR DESCRIPTION
This is essentially what we're using clippy for, to provide more exhaustive checking...no need to introduce a different term when these are already custom helper scripts.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
