### PR TITLE
Add production profile for maximum optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,11 @@ license = "MIT OR Apache-2.0"
 debug = 0
 
 [profile.release]
+lto = "thin"
+
+[profile.production]
+inherits = "release"
+codegen-units = 1
+lto = true
+panic = "abort"
 strip = true

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -46,7 +46,7 @@ fn dist_binary(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["build", "--release", "--bins"];
+        let args = vec!["build", "--profile", "production", "--bins"];
         cmd.args(args).run()?;
     }
 


### PR DESCRIPTION
This is what we'll use to generate the distributable artifacts. Some of these things don't exist on the default release profile because there's an aversion to making compilation times longer.

This also moves `strip` to just the production profile and adds "thin" LTO to the release profile. It'll be nice to have a faster version of LTO for local release builds (and benchmarks), but it won't add too much time for compiling.

See:
- https://doc.rust-lang.org/cargo/reference/profiles.html
- https://nnethercote.github.io/perf-book/build-configuration.html
- https://github.com/rust-lang/cargo/issues/11298

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
