### PR TITLE
Switch from codespell to typos for spell checking

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,0 @@
-[codespell]
-builtin = clear,rare,usage,en-GB_to_en-US
-check-filenames =
-check-hidden =
-ignore-words-list = crate
-skip = ./.git,./.github/cue/cue.mod/pkg,./.jj,./target
-uri-ignore-words-list = *

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -43,12 +43,6 @@ _#checkoutCode: _#step & {
 	uses: "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab"
 }
 
-// https://github.com/codespell-project/actions-codespell/releases
-_#codespell: _#step & {
-	name: "Check common misspellings"
-	uses: "codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461"
-}
-
 // https://github.com/actions/deploy-pages/releases
 _#deployPages: _#step & {
 	id:   "deployment"
@@ -135,6 +129,12 @@ _testRust: [
 		run:  "cargo test --locked --doc"
 	},
 ]
+
+// https://github.com/crate-ci/typos/releases
+_#typos: _#step & {
+	name: "Check common misspellings"
+	uses: "crate-ci/typos@38a1b194811847c93a72ab95f06d55b33806a160"
+}
 
 // https://github.com/actions/upload-pages-artifact/releases
 _#uploadPagesArtifact: _#step & {

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -23,21 +23,21 @@ wordsmith: _#useMergeQueue & {
 			]
 		}
 
-		spellcheck: {
-			name: "spellcheck"
+		spell_check: {
+			name: "spell check"
 			needs: ["changes"]
 			"runs-on": defaultRunner
 			if:        "github.event_name == 'pull_request'"
 			steps: [
 				_#checkoutCode,
-				_#codespell,
+				_#typos,
 			]
 		}
 
 		merge_queue: needs: [
 			"changes",
 			"markdown_format",
-			"spellcheck",
+			"spell_check",
 		]
 	}
 }

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -60,8 +60,8 @@ jobs:
         with:
           prettier_version: 2.8.8
           prettier_options: --check --color --prose-wrap always ${{ needs.changes.outputs.markdown_files }}
-  spellcheck:
-    name: spellcheck
+  spell_check:
+    name: spell check
     needs:
       - changes
     runs-on: ubuntu-latest
@@ -70,13 +70,13 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Check common misspellings
-        uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461
+        uses: crate-ci/typos@38a1b194811847c93a72ab95f06d55b33806a160
   merge_queue:
     name: wordsmith workflow ready
     needs:
       - changes
       - markdown_format
-      - spellcheck
+      - spell_check
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -100,9 +100,9 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: spellcheck'
+      - name: 'Check status of job_id: spell_check'
         run: |-
-          RESULT="${{ needs.spellcheck.result }}";
+          RESULT="${{ needs.spell_check.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default]
+locale = "en-us"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,14 +133,14 @@ tools to enforce formatting and style conventions for non-Rust files. Ensure
 that you have the following tools installed:
 
 - [actionlint][] for linting GitHub Actions workflow files
-- [codespell][] for spell checking all files
 - [CUE][] for generating and validating YAML files
 - [Prettier][] for formatting Markdown files
+- [typos][] for spell checking all files
 
 [actionlint]: https://github.com/rhysd/actionlint
-[codespell]: https://github.com/codespell-project/codespell
 [CUE]: https://cuelang.org/
 [Prettier]: https://prettier.io/
+[typos]: https://github.com/crate-ci/typos
 
 ## Contribution Guidelines
 
@@ -244,6 +244,8 @@ commands by running:
 cargo xtask --help
 ```
 
+[xtask]: https://github.com/matklad/cargo-xtask
+
 For example:
 
 - Generate and open an HTML code coverage report
@@ -257,8 +259,6 @@ For example:
   ```
   cargo xtask test
   ```
-
-[xtask]: https://github.com/matklad/cargo-xtask
 
 Most other commands are the same as any standard Rust project:
 

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -22,21 +22,16 @@ pub fn cargo_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
     )
 }
 
-pub fn codespell_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
-    create_cmd(
-        "codespell",
-        "https://github.com/codespell-project/codespell",
-        config,
-        sh,
-    )
-}
-
 pub fn cue_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
     create_cmd("cue", "https://cuelang.org/", config, sh)
 }
 
 pub fn prettier_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
     create_cmd("prettier", "https://prettier.io", config, sh)
+}
+
+pub fn typos_cmd<'a>(config: &Config, sh: &'a Shell) -> Option<Cmd<'a>> {
+    create_cmd("typos", "https://github.com/crate-ci/typos", config, sh)
 }
 
 fn create_cmd<'a>(

--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use xshell::Shell;
 
-use crate::commands::{actionlint_cmd, cargo_cmd, codespell_cmd, cue_cmd, prettier_cmd};
+use crate::commands::{actionlint_cmd, cargo_cmd, cue_cmd, prettier_cmd, typos_cmd};
 use crate::utils::{find_files, project_root, to_relative_paths, verbose_cd};
 use crate::Config;
 
@@ -19,7 +19,7 @@ pub fn spelling(config: &Config) -> Result<()> {
     let sh = Shell::new()?;
     verbose_cd(&sh, project_root());
 
-    let cmd_option = codespell_cmd(config, &sh);
+    let cmd_option = typos_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
         let args = vec!["--write-changes"];
         cmd.args(args).run()?;


### PR DESCRIPTION
These are very similar tools, but typos is written in Rust (versus Python), and should be easier for users to install. It's also quite a bit faster and will hopefully require less tweaking. When testing it on some other repos, it caught some typos that codespell did not, but that's mostly due to differences in project dictionaries. That said, it does do some filetype detection and accounts for language-specific quirks, as well as the distinction between identifiers vs words, which is great.

See:
- https://github.com/crate-ci/typos

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
