### PR TITLE
Tweak documentation for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ For example:
   cargo xtask coverage.html
   ```
 
-- Run all tests via Nextest and generate/review snapshots
+- Run all tests/doctests and generate Insta snapshots
 
   ```
   cargo xtask test
@@ -274,15 +274,20 @@ Most other commands are the same as any standard Rust project:
   cargo +nightly fmt
   ```
 
-- Run tests and doctests
+- Run the tests
 
   ```
   cargo nextest run
+  ```
+
+- Run the doctests
+
+  ```
   cargo test --doc
   ```
 
-- Build and run the release version:
+- Build and run the binary:
 
   ```
-  cargo run --release --bin mybin
+  cargo run --bin mybin --
   ```

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -33,7 +33,7 @@ pub fn test_with_snapshots(config: &Config) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["insta", "test", "--test-runner", "nextest", "--review"];
+        let args = vec!["insta", "test", "--test-runner", "nextest"];
         cmd.args(args).run()?;
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,7 +33,7 @@ TASKS:
     fixup.rust             Fix lints and format Rust files in-place
     fixup.spelling         Fix common misspellings across all files in-place
     install                Install required Rust components and Cargo dependencies
-    test                   Run all tests via Nextest and generate/review snapshots
+    test                   Run all tests/doctests and generate Insta snapshots
 ";
 
 enum Task {


### PR DESCRIPTION
Unfortunately, I uncovered an issue with trying to run the tests via Insta with the `--review` flag using our `cargo xtask test` wrapper, as once the interactive review process starts, it would panic with:

> Too many open files (os error 24)

Instead, we can just run the test command, which will fail if there is a snapshot needing review, and then run `cargo insta review` afterward.

I'm also splitting up tests versus doctests instructions, because doctests are very slow (each one is compiled as a separate binary), so it's likely that you wouldn't normally want to run them. Our test wrapper is still comprehensive though.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
