### PR TITLE
Add xtask for watching and generating the Rustdocs

### DIFF
--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -54,3 +54,21 @@ pub fn watch_clippy(config: &Config) -> Result<()> {
 
     Ok(())
 }
+
+pub fn watch_doc(config: &Config) -> Result<()> {
+    let sh = Shell::new()?;
+    verbose_cd(&sh, project_root());
+
+    let cmd_option = cargo_cmd(config, &sh);
+    if let Some(_cmd) = cmd_option {
+        let args = vec!["doc", "--no-deps", "--open"];
+        cargo_cmd(config, &sh).unwrap().args(args).run()?;
+
+        println!("\nPress Ctrl-C to stop the program.");
+
+        let args = vec!["watch", "--postpone", "--why", "-x", "doc --no-deps"];
+        cargo_cmd(config, &sh).unwrap().args(args).run()?;
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,6 +27,7 @@ TASKS:
     coverage               Generate and print a code coverage report summary
     coverage.html          Generate and open an HTML code coverage report
     dist                   Package project assets into distributable artifacts
+    doc                    Watch for file changes and auto-trigger doc generation
     fixup                  Run all fixup xtasks, editing files in-place
     fixup.github-actions   Format CUE files in-place and regenerate CI YAML files
     fixup.markdown         Format Markdown files in-place
@@ -41,6 +42,7 @@ enum Task {
     Coverage,
     CoverageHtml,
     Dist,
+    Doc,
     Fixup,
     FixupGithubActions,
     FixupMarkdown,
@@ -69,6 +71,7 @@ fn main() -> Result<()> {
             Task::Coverage => coverage::report_summary(&config)?,
             Task::CoverageHtml => coverage::html_report(&config)?,
             Task::Dist => dist::dist(&config)?,
+            Task::Doc => dev::watch_doc(&config)?,
             Task::Fixup => fixup::everything(&config)?,
             Task::FixupGithubActions => fixup::github_actions(&config)?,
             Task::FixupMarkdown => fixup::markdown(&config)?,
@@ -106,6 +109,7 @@ fn parse_args() -> Result<Config> {
                     "coverage" => Task::Coverage,
                     "coverage.html" => Task::CoverageHtml,
                     "dist" => Task::Dist,
+                    "doc" => Task::Doc,
                     "fixup" => Task::Fixup,
                     "fixup.github-actions" => Task::FixupGithubActions,
                     "fixup.markdown" => Task::FixupMarkdown,


### PR DESCRIPTION
The script will run an initial generation of the docs and open them in the user's browser. It then sets up `cargo-watch` to wait for file changes, and then will regenerate the docs.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [x] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
