### PR TITLE
Dependabot Bumps

### DIFF
--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -86,7 +86,8 @@ _#installTool: _#step & {
 // https://github.com/actions/labeler/releases
 _#labeler: _#step & {
 	name: "Label pull request based on paths of changed files"
-	uses: "actions/labeler@0776a679364a9a16110aac8d0f40f5e11009e327"
+	uses: "actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375"
+	with: dot: true
 }
 
 // https://github.com/dorny/paths-filter/releases

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -140,7 +140,7 @@ _testRust: [
 // https://github.com/crate-ci/typos/releases
 _#typos: _#step & {
 	name: "Check common misspellings"
-	uses: "crate-ci/typos@38a1b194811847c93a72ab95f06d55b33806a160"
+	uses: "crate-ci/typos@20b36ca07fa1bfe124912287ac8502cf12f140e6"
 }
 
 // https://github.com/actions/upload-pages-artifact/releases

--- a/.github/cue/shared-steps.cue
+++ b/.github/cue/shared-steps.cue
@@ -79,7 +79,7 @@ _#installRust: _#step & {
 // https://github.com/taiki-e/install-action/releases
 _#installTool: _#step & {
 	name: "Install \(with.tool)"
-	uses: "taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3"
+	uses: "taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299"
 	with: tool: string
 }
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+# See https://github.com/marketplace/actions/labeler for more information.
+
 dependencies:
   - Cargo.lock
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,4 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label pull request based on paths of changed files
-        uses: actions/labeler@0776a679364a9a16110aac8d0f40f5e11009e327
+        uses: actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375
+        with:
+          dot: true

--- a/.github/workflows/preload-caches.yml
+++ b/.github/workflows/preload-caches.yml
@@ -85,7 +85,7 @@ jobs:
           shared-key: stable-${{ matrix.platform }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors
@@ -120,7 +120,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-nextest
       - name: Check packages and dependencies for errors

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
           shared-key: stable-${{ matrix.platform }}
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-nextest
       - name: Compile tests
@@ -154,7 +154,7 @@ jobs:
           shared-key: msrv-ubuntu-latest
         timeout-minutes: 5
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-nextest
       - name: Compile tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set override to beta Rust
         run: rustup override set beta
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3
+        uses: taiki-e/install-action@835cdc15ee7680334982c900847bcafb86487299
         with:
           tool: cargo-nextest
       - name: Compile tests

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Check common misspellings
-        uses: crate-ci/typos@38a1b194811847c93a72ab95f06d55b33806a160
+        uses: crate-ci/typos@20b36ca07fa1bfe124912287ac8502cf12f140e6
   merge_queue:
     name: wordsmith workflow ready
     needs:


### PR DESCRIPTION
Note that dependabot gets confused with the `typos` version, since upstream is publishing multiple projects in the same repository.

Related to #158, #159, and #160

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
