### PR TITLE
Add build script to inject Git built-time metadata

### DIFF
--- a/crates/mybin/build.rs
+++ b/crates/mybin/build.rs
@@ -1,0 +1,45 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let pkg_name = env!("CARGO_PKG_NAME").to_ascii_uppercase();
+
+    let commit_hash = git_command(&["rev-parse", "HEAD"]).map(|hash| {
+        println!("cargo:rustc-env={pkg_name}_COMMIT_HASH={hash}");
+        hash[..12].to_string()
+    });
+
+    let commit_date = git_command(&["show", "-s", "--format=%cs"]).map(|date| {
+        println!("cargo:rustc-env={pkg_name}_COMMIT_DATE={date}");
+        date
+    });
+
+    let is_dirty = Command::new("git")
+        .args(["diff", "--quiet", "HEAD", "--"])
+        .status()
+        .map_or(false, |status| !status.success());
+
+    if let (Some(hash), Some(date)) = (commit_hash, commit_date) {
+        let dirty_flag = if is_dirty { ".dirty" } else { "" };
+        let version = format!(
+            "{} ({}{} {})",
+            env!("CARGO_PKG_VERSION"),
+            hash,
+            dirty_flag,
+            date
+        );
+        println!("cargo:rustc-env={pkg_name}_VERSION={version}");
+    }
+}
+
+fn git_command(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}

--- a/crates/mybin/src/main.rs
+++ b/crates/mybin/src/main.rs
@@ -9,4 +9,10 @@ fn main() {
     println!("Unshuffled: {nums:?}");
     shuffle_array(&mut nums);
     println!("Shuffled:   {nums:?}");
+
+    println!("mybin {}", get_version());
+}
+
+fn get_version() -> &'static str {
+    option_env!("MYBIN_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }


### PR DESCRIPTION
This allows our application to pull useful information from the environment when compiling, so we can have build metadata info displayed for version information, etc..

The format is based on what rustc does; it will display the commit hash and commit date, but additionally will add a `.dirty` flag if the repository was not clean.

Using 12 characters to abbreviate the Git hash should be more than sufficient to be unambiguous.

For example:

```
MYBIN_COMMIT_HASH="8b5396297b8896736bef3a83c161cb08d5a4ddcf"
MYBIN_COMMIT_DATE="2023-06-05"
MYBIN_VERSION="0.1.0 (8b5396297b88 2023-06-05)"
```

See:
- https://blog.cuviper.com/2013/11/10/how-short-can-git-abbreviate/

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
