### PR TITLE
Fix inconsistent clippy attribute definitions

### DIFF
--- a/crates/mybin/src/main.rs
+++ b/crates/mybin/src/main.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::nursery, clippy::pedantic)]
+
 use mylib::{add, shuffle_array};
 
 fn main() {

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::nursery, clippy::pedantic)]
-
 use std::path::PathBuf;
 use std::{env, fs};
 


### PR DESCRIPTION
The dist module already picks this up from xtask main.rs, and we should also have it on the top of our mybin main.rs as well.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
