### PR TITLE
Clean up the xtask dist generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ license = "MIT OR Apache-2.0"
 debug = 0
 
 [profile.release]
-lto = "thin"
-
-[profile.production]
-inherits = "release"
 codegen-units = 1
 lto = true
 panic = "abort"

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -19,6 +19,7 @@ struct Package {
     #[allow(dead_code)]
     name: String,
     targets: Vec<Target>,
+    version: String,
 }
 
 #[derive(Debug, DeJson)]
@@ -35,8 +36,8 @@ pub fn dist(config: &Config) -> Result<()> {
     }
     let binaries = project_binaries(config)?;
 
-    for binary in &binaries {
-        let dest_dir = dist_dir().join(binary);
+    for (binary, version) in &binaries {
+        let dest_dir = dist_dir().join(format!("{binary}-{version}"));
         fs::create_dir_all(&dest_dir)?;
 
         build_binary(config, binary, &dest_dir)?;
@@ -88,7 +89,7 @@ fn copy_docs(dest_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn project_binaries(config: &Config) -> Result<Vec<String>> {
+fn project_binaries(config: &Config) -> Result<Vec<(String, String)>> {
     let sh = Shell::new()?;
     let mut binaries = Vec::new();
 
@@ -103,7 +104,7 @@ fn project_binaries(config: &Config) -> Result<Vec<String>> {
         for package in metadata.packages {
             for target in &package.targets {
                 if target.name != "xtask" && target.kind.contains(&"bin".to_string()) {
-                    binaries.push(target.name.clone());
+                    binaries.push((target.name.clone(), package.version.clone()));
                 }
             }
         }

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -51,7 +51,7 @@ fn build_binary(config: &Config, binary: &str, dest_dir: &Path) -> Result<()> {
 
     let cmd_option = cargo_cmd(config, &sh);
     if let Some(cmd) = cmd_option {
-        let args = vec!["build", "--profile", "production", "--bin", binary];
+        let args = vec!["build", "--release", "--bin", binary];
         cmd.args(args).run()?;
     }
 
@@ -60,7 +60,7 @@ fn build_binary(config: &Config, binary: &str, dest_dir: &Path) -> Result<()> {
     } else {
         binary.to_string()
     };
-    let src = production_dir().join(&binary_filename);
+    let src = release_dir().join(&binary_filename);
     let dest = dest_dir.join(&binary_filename);
 
     fs::copy(&src, &dest)?;
@@ -115,8 +115,8 @@ fn dist_dir() -> PathBuf {
     target_dir().join("dist")
 }
 
-fn production_dir() -> PathBuf {
-    target_dir().join("production")
+fn release_dir() -> PathBuf {
+    target_dir().join("release")
 }
 
 fn target_dir() -> PathBuf {


### PR DESCRIPTION
No reason to invent something new that's not discoverable or intuitive to developers in the community. We can just have our highly-optimized settings on the normal release profile. The dist destination directory should also have the version number in there.

# Checklist

- [x] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
