### PR TITLE
Experiment with scheduled job names

### DIFF
--- a/.github/workflows/on-schedule-weekly.yml
+++ b/.github/workflows/on-schedule-weekly.yml
@@ -14,9 +14,9 @@ concurrency:
 
 jobs:
   check_rust_beta:
-    name: check rust beta
+    name: check rust / beta
     uses: EarthmanMuons/reusable-workflows/.github/workflows/check-rust-beta.yml@main
 
   check_rust_miri:
-    name: check rust miri
+    name: check rust / miri
     uses: EarthmanMuons/reusable-workflows/.github/workflows/check-rust-miri.yml@main


### PR DESCRIPTION
GitHub ends up hiding portions of names with a slash in them, but I'm not sure what happens for reusable jobs if the name is set with a slash from the caller side...let's find out.

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
