### PR TITLE
Use prefix "auto-" to namespace automatic jobs

### DIFF
--- a/.github/workflows/auto-label-pull-request.yml
+++ b/.github/workflows/auto-label-pull-request.yml
@@ -1,4 +1,4 @@
-name: label pull request
+name: auto-label pull request
 
 on:
   pull_request_target:


### PR DESCRIPTION
This is a naming convention I'm trying out for jobs that have unique triggers that shouldn't ever need to be manually run.

<!-- Please provide a brief summary of your changes and any references to related issues. Include detailed descriptions in the commit message(s) directly. -->

<!-- Address review comments by rewriting the branch, rather than adding commits on top. You'll need to force push when updating the pull request. -->

# Checklist

- [ ] Ran `cargo xtask fixup` for formatting and linting
- [ ] Modified all relevant documentation
- [ ] Updated `CHANGELOG.md` per "Keep a Changelog" format
- [ ] Added tests covering any code changes
